### PR TITLE
zero filled loader segments

### DIFF
--- a/dev_build.py
+++ b/dev_build.py
@@ -81,7 +81,7 @@ def main():
     if not BUILD_DIR.exists():
         BUILD_DIR.mkdir()
 
-    tool_rebuild = f"cd {CWD / 'tool/microkit'} && cargo build --release"
+    tool_rebuild = f"cd {CWD / 'tool/microkit'} && cargo build"
     r = system(tool_rebuild)
     assert r == 0
 
@@ -90,7 +90,7 @@ def main():
     make_env["MICROKIT_BOARD"] = args.board
     make_env["MICROKIT_CONFIG"] = args.config
     make_env["MICROKIT_SDK"] = str(release)
-    make_env["MICROKIT_TOOL"] = (CWD / "tool/microkit/target/release/microkit").absolute()
+    make_env["MICROKIT_TOOL"] = (CWD / "tool/microkit/target/debug/microkit").absolute()
     make_env["LLVM"] = str(args.llvm)
 
     # Choose the makefile based on the `--example-from-sdk` command line flag

--- a/libmicrokit/src/main.c
+++ b/libmicrokit/src/main.c
@@ -18,20 +18,22 @@
 #define PD_MASK 0xff
 #define CHANNEL_MASK 0x3f
 
+#define SECTION(sec) __attribute__((__section__(sec)))
+
 /* All globals are prefixed with microkit_* to avoid clashes with user defined globals. */
 
-bool microkit_passive;
-char microkit_name[MICROKIT_PD_NAME_LENGTH];
+bool microkit_passive SECTION(".data.patched");
+char microkit_name[MICROKIT_PD_NAME_LENGTH] SECTION(".data.patched");
 /* We use seL4 typedefs as this variable is exposed to the libmicrokit header
  * and we do not want to rely on compiler built-in defines. */
 seL4_Bool microkit_have_signal = seL4_False;
 seL4_CPtr microkit_signal_cap;
 seL4_MessageInfo_t microkit_signal_msg;
 
-seL4_Word microkit_irqs;
-seL4_Word microkit_notifications;
-seL4_Word microkit_pps;
-seL4_Word microkit_ioports;
+seL4_Word microkit_irqs SECTION(".data.patched");
+seL4_Word microkit_notifications SECTION(".data.patched");
+seL4_Word microkit_pps SECTION(".data.patched");
+seL4_Word microkit_ioports SECTION(".data.patched");
 
 extern seL4_IPCBuffer __sel4_ipc_buffer_obj;
 

--- a/loader/src/cutil.c
+++ b/loader/src/cutil.c
@@ -18,6 +18,14 @@ void *memcpy(void *dst, const void *src, size_t sz)
     return dst;
 }
 
+void memzero(void *dst, size_t sz)
+{
+    char *dst_ = dst;
+    for (size_t i = 0; i < sz; i++) {
+        dst_[i] = 0x0;
+    }
+}
+
 void *memmove(void *restrict dest, const void *restrict src, size_t n)
 {
     unsigned char *d = (unsigned char *)dest;
@@ -44,3 +52,4 @@ void *memmove(void *restrict dest, const void *restrict src, size_t n)
 
     return dest;
 }
+

--- a/loader/src/cutil.h
+++ b/loader/src/cutil.h
@@ -19,4 +19,6 @@
 
 void *memcpy(void *dst, const void *src, size_t sz);
 
+void memzero(void *dst, size_t sz);
+
 void *memmove(void *restrict dest, const void *restrict src, size_t n);

--- a/loader/src/loader.c
+++ b/loader/src/loader.c
@@ -84,8 +84,10 @@ static void print_loader_data(void)
         puthex32(i);
         puts("   addr: ");
         puthex64(r->load_addr);
-        puts("   size: ");
-        puthex64(r->size);
+        puts("   file size: ");
+        puthex64(r->file_size);
+        puts("   memory size: ");
+        puthex64(r->memory_size);
         puts("   offset: ");
         puthex64(r->offset);
         puts("   type: ");
@@ -102,7 +104,10 @@ static void copy_data(void)
         puts("LDR|INFO: copying region ");
         puthex32(i);
         puts("\n");
-        memcpy((void *)(uintptr_t)r->load_addr, base + r->offset, r->size);
+        memcpy((void *)(uintptr_t)r->load_addr, base + r->offset, r->file_size);
+
+        // we are guaranteed by the microkit tool that memory_size >= file_size
+        memzero((void *)(r->load_addr + r->file_size), r->memory_size - r->file_size);
     }
 }
 

--- a/loader/src/loader.h
+++ b/loader/src/loader.h
@@ -13,7 +13,10 @@
 
 struct region {
     uintptr_t load_addr;
-    uintptr_t size;
+    // The size of this region in the loader data 'file'
+    uintptr_t file_size;
+    // The size of this region in memory, zero-padded
+    uintptr_t memory_size;
     uintptr_t offset;
     uintptr_t type;
 };

--- a/monitor/src/main.c
+++ b/monitor/src/main.c
@@ -50,16 +50,19 @@
 #define BASE_SCHED_CONTEXT_CAP 138
 #define BASE_NOTIFICATION_CAP 202
 
+#define SECTION(sec) __attribute__((__section__(sec)))
+#define UNUSED __attribute__((unused))
+
 extern seL4_IPCBuffer __sel4_ipc_buffer_obj;
 seL4_IPCBuffer *__sel4_ipc_buffer = &__sel4_ipc_buffer_obj;
 
-char pd_names[MAX_PDS][MAX_NAME_LEN];
-seL4_Word pd_names_len;
-char vm_names[MAX_VMS][MAX_NAME_LEN] __attribute__((unused));
-seL4_Word vm_names_len;
+char pd_names[MAX_PDS][MAX_NAME_LEN] SECTION(".data.patched");
+seL4_Word pd_names_len SECTION(".data.patched");
+char vm_names[MAX_VMS][MAX_NAME_LEN] SECTION(".data.patched") UNUSED;
+seL4_Word vm_names_len SECTION(".data.patched");
 
 /* For reporting potential stack overflows, keep track of the stack regions for each PD. */
-seL4_Word pd_stack_bottom_addrs[MAX_PDS];
+seL4_Word pd_stack_bottom_addrs[MAX_PDS] SECTION(".data.patched");
 
 /* Sanity check that the architecture specific macro have been set. */
 #if defined(ARCH_aarch64)

--- a/tool/microkit/src/capdl/packaging.rs
+++ b/tool/microkit/src/capdl/packaging.rs
@@ -56,7 +56,7 @@ fn reserialise_spec(
                     .segments
                     .get(data.elf_seg_idx)
                     .unwrap()
-                    .data()[data.elf_seg_data_range.clone()],
+                    .data[data.elf_seg_data_range.clone()],
             )),
         });
 

--- a/tool/microkit/src/lib.rs
+++ b/tool/microkit/src/lib.rs
@@ -106,7 +106,7 @@ impl Region {
     }
 
     pub fn data<'a>(&self, elf: &'a elf::ElfFile) -> &'a Vec<u8> {
-        elf.segments[self.segment_idx].data()
+        &elf.segments[self.segment_idx].data
     }
 }
 


### PR DESCRIPTION
Opening this just to recognise that it's here, I'm unlikely to work on this soon.

This adds support for having loader regions that are zero-filled, where either the entire region is zeroed or the end part, as in for ELF files (we are really just reinventing an ELF file here).

At the moment, whilst the loader.rs and loader.c code works fine, making the changes to use this for the restof the tool breaks. This is essentially because we used to be able to patch symbols that were located in the `.bss` region as we stored the zero-filled data, now, we cannot. See the changes for `.data.patched` in libmicrokit for an example of how this affects people.

The same thing will happen for most user programs, I think. So this might break things.

However, if we removed the changes to use it for ELF files, we can remove the hardcoding for the heap zero-initialised region (though this is being removed anyway).