### PR TITLE
IOMMU: Refactor the memory module

### DIFF
--- a/docs/manual.md
+++ b/docs/manual.md
@@ -1013,12 +1013,16 @@ The `protection_domain` element has the same attributes as any other protection 
 
 On x86-64, a PD with a VCPU cannot have child PDs.
 
-The `virtual_machine` element has the following attributes:
+The `virtual_machine` element has the following attribute:
 
 * `name`: A unique name for the virtual machine
+
+On ARM, it supports the following additional attributes:
 * `priority`: (optional) The priority of the virtual machine (integer 0 to 254); defaults to 0.
 * `budget`: (optional) The VM's budget in microseconds; defaults to 1,000.
 * `period`: (optional) The VM's period in microseconds; must not be smaller than the budget; defaults to the budget.
+
+On x86-64, the VM shares its scheduling parameters with the parent PD.
 
 Additionally, it supports the following child elements:
 

--- a/docs/manual.md
+++ b/docs/manual.md
@@ -109,7 +109,7 @@ This document attempts to clearly describe all of these terms, however as the co
 * [interrupt](#irq)
 * [fault](#fault)
 * [ioport](#ioport)
-* [io address space](#io_address_space)
+* [IO address space](#io_address_space)
 
 ## System {#system}
 
@@ -244,10 +244,10 @@ The mapping has a number of attributes, which include:
 * permissions (read, write and execute)
 
 *Note:* On x86 a memory region can also be *mapped* into one or more
-io address spaces. This type of mapping is known as an *iomap*. It supports
+IO address spaces. This type of mapping is known as an *iomap*. It supports
 a number of attributes, which include:
 
-* the io virtual address at which the region is mapped in the io address space
+* the io virtual address at which the region is mapped in the IO address space
 * permissions (read, write)
 
 **Note:** When a memory region is mapped into multiple protection
@@ -1101,12 +1101,12 @@ For instance, `<cap_tcb slot="1" pd="alpha">` will place the TCB of PD 'alpha' i
 The `io_address_space` element describes an address space used to isolate a given device.
 
 It supports the following attributes:
-* `name`: A unique name for the io address space
+* `name`: A unique name for the IO address space
 * `peripheral_id`: A unique identifier. This must match the identifier used by the hardware IOMMU or SMMU to identify devices.
 
 The `io_address_space` element supports the following elements as children:
 
-* `iomap`: This is used to map a *memory_region* into the io address space.
+* `iomap`: This is used to map a *memory_region* into the IO address space.
 
 The `iomap` element supports the following attributes:
 * `mr`: Identifies the memory region to map.

--- a/docs/manual.md
+++ b/docs/manual.md
@@ -109,6 +109,7 @@ This document attempts to clearly describe all of these terms, however as the co
 * [interrupt](#irq)
 * [fault](#fault)
 * [ioport](#ioport)
+* [io address space](#io_address_space)
 
 ## System {#system}
 
@@ -242,6 +243,13 @@ The mapping has a number of attributes, which include:
 * caching attributes (mostly relevant for device memory)
 * permissions (read, write and execute)
 
+*Note:* On x86 a memory region can also be *mapped* into one or more
+io address spaces. This type of mapping is known as an *iomap*. It supports
+a number of attributes, which include:
+
+* the io virtual address at which the region is mapped in the io address space
+* permissions (read, write)
+
 **Note:** When a memory region is mapped into multiple protection
 domains, the attributes used for different mappings may vary.
 
@@ -366,6 +374,12 @@ delivered to another PD, the fault being handled depends on when the parent PD i
 ## I/O Ports {#ioport}
 
 I/O ports are x86 mechanisms to access certain physical devices (e.g. PC serial ports or PCI) using the `in` and `out` CPU instructions. The system description specifies if a protection domain have access to certain port address ranges. These accesses will be executed by seL4 and the result returned to protection domains.
+
+## IO Address Spaces {#io_address_space}
+
+IO Address Spaces provide a way to isolate device memory accesses within a fixed virtual address space. The isolation provided by the address space is enforced by the underlying hardware IOMMU or SMMU.
+
+IO Address Spaces allow *memory regions* to be mapped to a provided base IO virtual address. These IO virtual addresses will be translated by the hardware IOMMU or SMMU to the underlying physical memory that backs the memory region.
 
 # SDK {#sdk}
 
@@ -1082,6 +1096,23 @@ See the 'cap_sharing' example packaged in your SDK or [on GitHub](https://github
 All capability elements (currently) all support the `pd` attribute, the name of the protection domain that the capability is from.
 For instance, `<cap_tcb slot="1" pd="alpha">` will place the TCB of PD 'alpha' in the CSpace of the current PD.
 
+## `io_address_space`
+
+The `io_address_space` element describes an address space used to isolate a given device.
+
+It supports the following attributes:
+* `name`: A unique name for the io address space
+* `peripheral_id`: A unique identifier. This must match the identifier used by the hardware IOMMU or SMMU to identify devices.
+
+The `io_address_space` element supports the following elements as children:
+
+* `iomap`: This is used to map a *memory_region* into the io address space.
+
+The `iomap` element supports the following attributes:
+* `mr`: Identifies the memory region to map.
+* `iovaddr`: Identifies the io virtual address at which to map the memory region.
+* `perms`: Identifies the permissions with which to map the memory region. Can be a combination of `r` (read), and `w` (write).
+           Defaults to read-write.
 
 ### Page sizes by architecture
 

--- a/docs/manual.md
+++ b/docs/manual.md
@@ -577,6 +577,7 @@ If the protection domain has children it must also implement:
     void microkit_deferred_irq_ack(microkit_channel ch);
     void microkit_pd_restart(microkit_child pd, seL4_Word entry_point);
     void microkit_pd_stop(microkit_child pd);
+    void microkit_pd_resume(microkit_child pd);
     void microkit_mr_set(seL4_Uint8 mr, seL4_Word value);
     seL4_Word microkit_mr_get(seL4_Uint8 mr);
     void microkit_vcpu_restart(microkit_child vcpu, seL4_Word entry_point);
@@ -754,6 +755,10 @@ This will set the program counter of the child protection domain to `entry_point
 ## `void microkit_pd_stop(microkit_child pd)`
 
 Stop the execution of the child protection domain with ID `pd`.
+
+## `void microkit_pd_resume(microkit_child pd)`
+
+Resume the execution of the child protection domain with ID `pd` that is stopped.
 
 ## `microkit_msginfo microkit_msginfo_new(uint64_t label, uint16_t count)`
 

--- a/docs/manual.md
+++ b/docs/manual.md
@@ -1101,14 +1101,18 @@ For instance, `<cap_tcb slot="1" pd="alpha">` will place the TCB of PD 'alpha' i
 The `io_address_space` element describes an address space used to isolate a given device.
 
 It supports the following attributes:
+
 * `name`: A unique name for the IO address space
 * `peripheral_id`: A unique identifier. This must match the identifier used by the hardware IOMMU or SMMU to identify devices.
+* `domain_id`: A unique domain identifier, synonymous with an ASID. This is not optional due to current
+                constraints with x86 only providing certain information at runtime.
 
 The `io_address_space` element supports the following elements as children:
 
 * `iomap`: This is used to map a *memory_region* into the IO address space.
 
 The `iomap` element supports the following attributes:
+
 * `mr`: Identifies the memory region to map.
 * `iovaddr`: Identifies the io virtual address at which to map the memory region.
 * `perms`: Identifies the permissions with which to map the memory region. Can be a combination of `r` (read), and `w` (write).

--- a/docs/manual.md
+++ b/docs/manual.md
@@ -1016,7 +1016,7 @@ On x86-64, a PD with a VCPU cannot have child PDs.
 The `virtual_machine` element has the following attributes:
 
 * `name`: A unique name for the virtual machine
-* `priority`: The priority of the virtual machine (integer 0 to 254).
+* `priority`: (optional) The priority of the virtual machine (integer 0 to 254); defaults to 0.
 * `budget`: (optional) The VM's budget in microseconds; defaults to 1,000.
 * `period`: (optional) The VM's period in microseconds; must not be smaller than the budget; defaults to the budget.
 

--- a/docs/manual.md
+++ b/docs/manual.md
@@ -1068,7 +1068,6 @@ It supports no attributes, but supports the following elements as children:
 * `cap_sc`: A capability to a protection domain's Scheduling Context (SC).
   If the protection domain is passive, this is a capability to the notification's scheduling context.
 * `cap_vspace`: A capability to a protection domain's VSpace.
-* `cap_cspace`: A capability to a protection domain's CSpace.
 
 All of the elements support the `slot` attribute, which is is an opaque identifier used to address the capability at runtime.
 To convert the `slot` to an `seL4_CPtr`, use the [`seL4_CPtr microkit_cspace_root_slot_to_cptr(seL4_Word slot)`](#libmicrokit_cspace_root_slot_to_cptr) function.

--- a/example/x86_64_iommu_dma_test/x86_64_iommu_dma_test.system
+++ b/example/x86_64_iommu_dma_test/x86_64_iommu_dma_test.system
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright 2026, UNSW
+
+ SPDX-License-Identifier: BSD-2-Clause
+-->
+<system>
+    <memory_region name="edu_mmio_window" size="0x10_0000" page_size="0x1000" phys_addr="0xfe00_0000" />
+    <memory_region name="dma_buffer" size="0x1000" page_size="0x1000" />
+    <io_address_space name="QEMU EDU" peripheral_id="0:4.0">
+        <iomap mr="dma_buffer" iovaddr="0x10_0000" />
+    </io_address_space>
+
+    <protection_domain name="x86_64_iommu_dma_test" priority="100">
+        <program_image path="x86_64_iommu_dma_test.elf" />
+        <map mr="edu_mmio_window" vaddr="0x2000_0000" perms="rw" cached="false" setvar_vaddr="edu_mmio_window_vaddr" />
+        <map mr="dma_buffer" vaddr="0x3000_0000" perms="rw" cached="true" setvar_vaddr="dma_buffer_vaddr" />
+        <ioport id="0" addr="0xcf8" size="8" setvar_id="pci_config_ioport_id" />
+    </protection_domain>
+</system>

--- a/libmicrokit/include/microkit.h
+++ b/libmicrokit/include/microkit.h
@@ -158,7 +158,21 @@ static inline void microkit_pd_stop(microkit_child pd)
     seL4_Error err;
     err = seL4_TCB_Suspend(BASE_TCB_CAP + pd);
     if (err != seL4_NoError) {
-        microkit_dbg_puts("microkit_pd_stop: error writing TCB registers\n");
+        microkit_dbg_puts("microkit_pd_stop: error stopping TCB '");
+        microkit_dbg_put32(pd);
+        microkit_dbg_puts("'\n");
+        microkit_internal_crash(err);
+    }
+}
+
+static inline void microkit_pd_resume(microkit_child pd)
+{
+    seL4_Error err;
+    err = seL4_TCB_Resume(BASE_TCB_CAP + pd);
+    if (err != seL4_NoError) {
+        microkit_dbg_puts("microkit_pd_resume: error resuming TCB '");
+        microkit_dbg_put32(pd);
+        microkit_dbg_puts("'\n");
         microkit_internal_crash(err);
     }
 }

--- a/tool/microkit/src/capdl/builder.rs
+++ b/tool/microkit/src/capdl/builder.rs
@@ -1221,25 +1221,6 @@ pub fn build_capdl_spec(
                 CapMapType::Tcb => capdl_util_make_tcb_cap(pd_src_shadow_cspace.tcb),
                 CapMapType::Sc => capdl_util_make_sc_cap(pd_src_shadow_cspace.sched_context),
                 CapMapType::VSpace => capdl_util_make_page_table_cap(pd_src_shadow_cspace.vspace),
-                CapMapType::CSpace => {
-                    let Some(named_object) =
-                        spec_container.get_root_object(pd_src_shadow_cspace.cspace)
-                    else {
-                        unreachable!("internal bug: couldn't find cnode with given obj id.");
-                    };
-                    let Object::CNode(ref cnode) = named_object.object else {
-                        unreachable!(
-                            "internal bug: got a non-CNode object id {} with name '{}'",
-                            usize::from(pd_src_shadow_cspace.cspace),
-                            named_object.name.as_ref().unwrap()
-                        );
-                    };
-
-                    let guard_size =
-                        kernel_config.cap_address_bits as u8 - PD_ROOT_CAP_BITS - cnode.size_bits;
-
-                    capdl_util_make_cnode_cap(pd_src_shadow_cspace.cspace, 0, guard_size)
-                }
             };
 
             // Map this into the destination pd's cspace and the specified slot.

--- a/tool/microkit/src/capdl/builder.rs
+++ b/tool/microkit/src/capdl/builder.rs
@@ -720,8 +720,8 @@ pub fn build_capdl_spec(
             &mut spec_container,
             &pd.name,
             PD_SCHEDCONTEXT_EXTRA_SIZE_BITS as u8,
-            pd.period,
-            pd.budget,
+            pd.sched_params.period,
+            pd.sched_params.budget,
             0x100 + pd_global_idx as u64,
         );
         let pd_sc_cap = capdl_util_make_sc_cap(pd_sc_obj_id);
@@ -955,8 +955,8 @@ pub fn build_capdl_spec(
                         &mut spec_container,
                         &format!("{}_{}", virtual_machine.name, vcpu.id),
                         PD_SCHEDCONTEXT_EXTRA_SIZE_BITS as u8,
-                        virtual_machine.period,
-                        virtual_machine.budget,
+                        virtual_machine.sched_params.period,
+                        virtual_machine.sched_params.budget,
                         0x100 + vcpu_idx as u64,
                     );
                     caps_to_bind_to_vm_tcbs.push(capdl_util_make_cte(
@@ -982,8 +982,8 @@ pub fn build_capdl_spec(
                         extra: Box::new(object::TcbExtraInfo {
                             ipc_buffer_addr: Word(0),
                             affinity: Word(vcpu_affinity.0.into()),
-                            prio: virtual_machine.priority,
-                            max_prio: virtual_machine.priority,
+                            prio: virtual_machine.sched_params.priority,
+                            max_prio: virtual_machine.sched_params.priority,
                             // Given the use cases of VMs, for now we always give them FPU access.
                             fpu_disabled: false,
                             resume: false,
@@ -1071,8 +1071,8 @@ pub fn build_capdl_spec(
             pd_tcb.extra.ipc_buffer_addr = Word(kernel_config.pd_ipc_buffer());
             pd_tcb.extra.sp = Word(kernel_config.pd_stack_top());
             pd_tcb.extra.master_fault_ep = None; // Not used on MCS kernel.
-            pd_tcb.extra.prio = pd.priority;
-            pd_tcb.extra.max_prio = pd.priority;
+            pd_tcb.extra.prio = pd.priority();
+            pd_tcb.extra.max_prio = pd.priority();
             pd_tcb.extra.fpu_disabled = !pd.fpu;
             pd_tcb.extra.resume = true;
 

--- a/tool/microkit/src/capdl/builder.rs
+++ b/tool/microkit/src/capdl/builder.rs
@@ -955,8 +955,8 @@ pub fn build_capdl_spec(
                         &mut spec_container,
                         &format!("{}_{}", virtual_machine.name, vcpu.id),
                         PD_SCHEDCONTEXT_EXTRA_SIZE_BITS as u8,
-                        virtual_machine.sched_params.period,
-                        virtual_machine.sched_params.budget,
+                        virtual_machine.sched_params.as_ref().unwrap().period,
+                        virtual_machine.sched_params.as_ref().unwrap().budget,
                         0x100 + vcpu_idx as u64,
                     );
                     caps_to_bind_to_vm_tcbs.push(capdl_util_make_cte(
@@ -982,8 +982,8 @@ pub fn build_capdl_spec(
                         extra: Box::new(object::TcbExtraInfo {
                             ipc_buffer_addr: Word(0),
                             affinity: Word(vcpu_affinity.0.into()),
-                            prio: virtual_machine.sched_params.priority,
-                            max_prio: virtual_machine.sched_params.priority,
+                            prio: virtual_machine.sched_params.as_ref().unwrap().priority,
+                            max_prio: virtual_machine.sched_params.as_ref().unwrap().priority,
                             // Given the use cases of VMs, for now we always give them FPU access.
                             fpu_disabled: false,
                             resume: false,

--- a/tool/microkit/src/capdl/builder.rs
+++ b/tool/microkit/src/capdl/builder.rs
@@ -11,7 +11,7 @@ use std::{
 };
 
 use sel4_capdl_initializer_types::{
-    object, CapTableEntry, Fill, FillEntry, FillEntryContent, FillEntryContentBootInfo,
+    object, Cap, CapTableEntry, Fill, FillEntry, FillEntryContent, FillEntryContentBootInfo,
     NamedObject, Object, ObjectId, Spec, Word,
 };
 
@@ -120,6 +120,29 @@ struct PDShadowCspace {
     sched_context: ObjectId,
     tcb: ObjectId,
     vspace: ObjectId,
+}
+
+impl PDShadowCspace {
+    /// Used for objects that are shared via <cnode> tag in the
+    /// SDF that needs `microkit_cspace_root_slot_to_cptr()`.
+    pub fn insert_cap_into_root_cnode(
+        &self,
+        spec_container: &mut CapDLSpecContainer,
+        idx: u32,
+        cap: Cap,
+    ) {
+        capdl_util_insert_cap_into_cspace(spec_container, self.cspace, idx, cap);
+    }
+
+    /// Used for Microkit objects under typical CSlots PD_BASE_*.
+    pub fn insert_cap_into_microkit_cnode(
+        &self,
+        spec_container: &mut CapDLSpecContainer,
+        idx: u32,
+        cap: Cap,
+    ) {
+        capdl_util_insert_cap_into_cspace(spec_container, self.microkit_cnode, idx, cap);
+    }
 }
 
 pub struct CapDLSpecContainer {
@@ -742,10 +765,8 @@ pub fn build_capdl_spec(
                 capdl_util_make_endpoint_cap(parent_ep_obj_id, true, true, true, badge);
 
             // Allow the parent PD to access the child's TCB:
-            let parent_cspace_obj_id = parent_shadow_cspace.microkit_cnode;
-            capdl_util_insert_cap_into_cspace(
+            parent_shadow_cspace.insert_cap_into_microkit_cnode(
                 &mut spec_container,
-                parent_cspace_obj_id,
                 (PD_BASE_PD_TCB_CAP + pd.id.unwrap()) as u32,
                 capdl_util_make_tcb_cap(pd_tcb_obj_id),
             );
@@ -1127,19 +1148,18 @@ pub fn build_capdl_spec(
     // Step 4. Create channels
     // *********************************
     for channel in system.channels.iter() {
-        let pd_a_cspace_id = pd_shadow_cspaces[&channel.end_a.pd].microkit_cnode;
-        let pd_b_cspace_id = pd_shadow_cspaces[&channel.end_b.pd].microkit_cnode;
-        let pd_a_ntfn_id = pd_shadow_cspaces[&channel.end_a.pd].notification;
-        let pd_b_ntfn_id = pd_shadow_cspaces[&channel.end_b.pd].notification;
+        let pd_a_shadow_cspace = &pd_shadow_cspaces[&channel.end_a.pd];
+        let pd_b_shadow_cspace = &pd_shadow_cspaces[&channel.end_b.pd];
+        let pd_a_ntfn_id = pd_a_shadow_cspace.notification;
+        let pd_b_ntfn_id = pd_b_shadow_cspace.notification;
 
         // We trust that the SDF parsing code have checked for duplicate IDs.
         if channel.end_a.notify {
             let pd_a_ntfn_cap_idx = PD_BASE_OUTPUT_NOTIFICATION_CAP + channel.end_a.id;
             let pd_a_ntfn_badge = 1 << channel.end_b.id;
             let pd_a_ntfn_cap = capdl_util_make_ntfn_cap(pd_b_ntfn_id, true, true, pd_a_ntfn_badge);
-            capdl_util_insert_cap_into_cspace(
+            pd_a_shadow_cspace.insert_cap_into_microkit_cnode(
                 &mut spec_container,
-                pd_a_cspace_id,
                 pd_a_ntfn_cap_idx as u32,
                 pd_a_ntfn_cap,
             );
@@ -1149,9 +1169,8 @@ pub fn build_capdl_spec(
             let pd_b_ntfn_cap_idx = PD_BASE_OUTPUT_NOTIFICATION_CAP + channel.end_b.id;
             let pd_b_ntfn_badge = 1 << channel.end_a.id;
             let pd_b_ntfn_cap = capdl_util_make_ntfn_cap(pd_a_ntfn_id, true, true, pd_b_ntfn_badge);
-            capdl_util_insert_cap_into_cspace(
+            pd_b_shadow_cspace.insert_cap_into_microkit_cnode(
                 &mut spec_container,
-                pd_b_cspace_id,
                 pd_b_ntfn_cap_idx as u32,
                 pd_b_ntfn_cap,
             );
@@ -1165,9 +1184,8 @@ pub fn build_capdl_spec(
                 .expect("exists as needs_ep() is true");
             let pd_a_ep_cap =
                 capdl_util_make_endpoint_cap(pd_b_ep_id, true, true, true, pd_a_ep_badge);
-            capdl_util_insert_cap_into_cspace(
+            pd_a_shadow_cspace.insert_cap_into_microkit_cnode(
                 &mut spec_container,
-                pd_a_cspace_id,
                 pd_a_ep_cap_idx as u32,
                 pd_a_ep_cap,
             );
@@ -1181,9 +1199,8 @@ pub fn build_capdl_spec(
                 .expect("exists as needs_ep() is true");
             let pd_b_ep_cap =
                 capdl_util_make_endpoint_cap(pd_a_ep_id, true, true, true, pd_b_ep_badge);
-            capdl_util_insert_cap_into_cspace(
+            pd_b_shadow_cspace.insert_cap_into_microkit_cnode(
                 &mut spec_container,
-                pd_b_cspace_id,
                 pd_b_ep_cap_idx as u32,
                 pd_b_ep_cap,
             );
@@ -1195,8 +1212,6 @@ pub fn build_capdl_spec(
     // *********************************
 
     for (pd_dest_idx, pd) in system.protection_domains.iter().enumerate() {
-        let pd_dest_cspace_id = pd_shadow_cspaces[&pd_dest_idx].cspace;
-
         for cap_map in pd.cap_maps.iter() {
             // TODO: Once we add more CapMap options, they might not all have
             // the pd_name. But for now, they do.
@@ -1228,9 +1243,8 @@ pub fn build_capdl_spec(
             };
 
             // Map this into the destination pd's cspace and the specified slot.
-            capdl_util_insert_cap_into_cspace(
+            pd_shadow_cspaces[&pd_dest_idx].insert_cap_into_root_cnode(
                 &mut spec_container,
-                pd_dest_cspace_id,
                 cap_map.slot as u32,
                 cap_map_obj,
             );

--- a/tool/microkit/src/capdl/builder.rs
+++ b/tool/microkit/src/capdl/builder.rs
@@ -742,7 +742,7 @@ pub fn build_capdl_spec(
                 capdl_util_make_endpoint_cap(parent_ep_obj_id, true, true, true, badge);
 
             // Allow the parent PD to access the child's TCB:
-            let parent_cspace_obj_id = parent_shadow_cspace.cspace;
+            let parent_cspace_obj_id = parent_shadow_cspace.microkit_cnode;
             capdl_util_insert_cap_into_cspace(
                 &mut spec_container,
                 parent_cspace_obj_id,

--- a/tool/microkit/src/capdl/builder.rs
+++ b/tool/microkit/src/capdl/builder.rs
@@ -18,14 +18,14 @@ use sel4_capdl_initializer_types::{
 use crate::{
     capdl::{
         irq::create_irq_handler_cap,
-        memory::{create_vspace, create_vspace_ept, map_page},
+        memory::{create_vspace, create_vspace_ept, AddressSpace},
         spec::{capdl_obj_physical_size_bits, BytesContent, ElfContent, FillContent},
         util::*,
     },
     elf::ElfFile,
     sdf::{
-        CapMapType, CpuCore, SysMap, SysMapPerms, SystemDescription, BUDGET_DEFAULT,
-        MONITOR_PD_NAME, MONITOR_PRIORITY,
+        CapMapType, CpuCore, Map, SystemDescription, BUDGET_DEFAULT, MONITOR_PD_NAME,
+        MONITOR_PRIORITY,
     },
     sel4::{Arch, Config, PageSize},
     util::{ranges_overlap, round_down, round_up},
@@ -145,6 +145,11 @@ impl PDShadowCspace {
     }
 }
 
+struct ElfSpecResult {
+    tcb: ObjectId,
+    address_space: AddressSpace,
+}
+
 pub struct CapDLSpecContainer {
     pub spec: Spec<FrameFill>,
     /// Track allocations as we build the system for later use by the report.
@@ -209,7 +214,7 @@ impl CapDLSpecContainer {
     /// as possible. These are the objects that will be created:
     /// -> TCB: Program counter set and VSpace capability bound.
     /// -> VSpace: all pages from the ELF mapped in.
-    /// Returns the object ID of the TCB
+    /// Returns ElfSpecResult containing the TCB object ID and the PDs address space.
     /// NOTE that all ELF frames will just be reference to the original ELF object rather than the actual data.
     /// So that symbols can be patched before the frames' data are filled in.
     fn add_elf_to_spec(
@@ -219,9 +224,10 @@ impl CapDLSpecContainer {
         pd_cpu: CpuCore,
         elf_id: usize,
         elf: &ElfFile,
-    ) -> Result<ObjectId, String> {
+    ) -> Result<ElfSpecResult, String> {
         // We assumes that ELFs and PDs have a one-to-one relationship. So for each ELF we create a VSpace.
-        let vspace_obj_id = create_vspace(self, sel4_config, pd_name);
+        let address_space = create_vspace(self, sel4_config, pd_name);
+        let vspace_obj_id = address_space.root();
         let vspace_cap = capdl_util_make_page_table_cap(vspace_obj_id);
 
         // For each loadable segment in the ELF, map it into the address space of this PD.
@@ -291,11 +297,9 @@ impl CapDLSpecContainer {
                     true,
                 );
 
-                match map_page(
+                match address_space.map_page(
                     self,
                     sel4_config,
-                    pd_name,
-                    vspace_obj_id,
                     frame_cap,
                     page_size_bytes,
                     cur_vaddr,
@@ -309,7 +313,7 @@ impl CapDLSpecContainer {
                             "add_elf_to_spec(): failed to map segment page to ELF because: {map_err_reason}"
                         ))
                     }
-                };
+                }
             }
         }
 
@@ -341,42 +345,47 @@ impl CapDLSpecContainer {
             object: Object::Tcb(tcb_inner_obj),
         };
 
-        Ok(self.add_root_object(tcb_obj))
+        Ok(ElfSpecResult {
+            tcb: self.add_root_object(tcb_obj),
+            address_space,
+        })
     }
 }
 
-/// Given a SysMap, page size, VSpace object ID, and a Vec of frame object ids,
-/// map all frames into the given VSpace at the requested vaddr.
-fn map_memory_region(
+/// Given a map, page size, address space, and a Vec of frame object ids, map
+/// all frames into the requested address space at the requested address.
+fn map_memory_region<M: Map>(
     spec_container: &mut CapDLSpecContainer,
     sel4_config: &Config,
-    pd_name: &str,
-    map: &SysMap,
+    map: &M,
     page_sz: u64,
-    target_vspace: ObjectId,
+    target_address_space: &AddressSpace,
     frames: &[ObjectId],
-) {
-    let mut cur_vaddr = map.vaddr;
-    let read = map.perms & SysMapPerms::Read as u8 != 0;
-    let write = map.perms & SysMapPerms::Write as u8 != 0;
-    let execute = map.perms & SysMapPerms::Execute as u8 != 0;
-    let cached = map.cached;
+) -> Result<(), String> {
+    let mut cur_vaddr = map.addr();
+    let read = map.read();
+    let write = map.write();
+    let execute = map.execute();
     for frame_obj_id in frames.iter() {
         // Make a cap for this frame.
-        let frame_cap = capdl_util_make_frame_cap(*frame_obj_id, read, write, execute, cached);
+        let frame_cap =
+            capdl_util_make_frame_cap(*frame_obj_id, read, write, execute, map.cached());
         // Map it into this PD address space.
-        map_page(
-            spec_container,
-            sel4_config,
-            pd_name,
-            target_vspace,
-            frame_cap,
-            page_sz,
-            cur_vaddr,
-        )
-        .unwrap();
+        target_address_space
+            .map_page(spec_container, sel4_config, frame_cap, page_sz, cur_vaddr)
+            .map_err(|err| {
+                format!(
+                    "failed to map {} for MR '{}' into address-space '{}' at {} {:#x}: {err}",
+                    map.element(),
+                    map.mr_name(),
+                    target_address_space.name(),
+                    map.addr_name(),
+                    cur_vaddr
+                )
+            })?;
         cur_vaddr += page_sz;
     }
+    Ok(())
 }
 
 /// Build a CapDL Spec according to the System Description File.
@@ -394,18 +403,16 @@ pub fn build_capdl_spec(
     // We expect the PD ELFs to be first and the monitor ELF last in the list of ELFs.
     let mon_elf_id = elfs.len() - 1;
     assert!(elfs.len() == system.protection_domains.len() + 1);
-    let monitor_tcb_obj_id = {
-        let monitor_elf = &elfs[mon_elf_id];
-        spec_container
-            .add_elf_to_spec(
-                kernel_config,
-                MONITOR_PD_NAME,
-                CpuCore(0),
-                mon_elf_id,
-                monitor_elf,
-            )
-            .unwrap()
-    };
+    let monitor_elf_spec = spec_container
+        .add_elf_to_spec(
+            kernel_config,
+            MONITOR_PD_NAME,
+            CpuCore(0),
+            mon_elf_id,
+            &elfs[mon_elf_id],
+        )
+        .unwrap();
+    let monitor_tcb_obj_id = monitor_elf_spec.tcb;
 
     // Create monitor fault endpoint object + cap
     let mon_fault_ep_obj_id =
@@ -453,18 +460,16 @@ pub fn build_capdl_spec(
     );
     let mon_stack_frame_cap =
         capdl_util_make_frame_cap(mon_stack_frame_obj_id, true, true, false, true);
-    let mon_vspace_obj_id =
-        capdl_util_get_vspace_id_from_tcb_id(&spec_container, monitor_tcb_obj_id);
-    map_page(
-        &mut spec_container,
-        kernel_config,
-        MONITOR_PD_NAME,
-        mon_vspace_obj_id,
-        mon_stack_frame_cap,
-        PageSize::Small as u64,
-        kernel_config.pd_stack_bottom(MON_STACK_SIZE),
-    )
-    .unwrap();
+    monitor_elf_spec
+        .address_space
+        .map_page(
+            &mut spec_container,
+            kernel_config,
+            mon_stack_frame_cap,
+            PageSize::Small as u64,
+            kernel_config.pd_stack_bottom(MON_STACK_SIZE),
+        )
+        .unwrap();
 
     // Create monitor IPC Bufffer
     let mon_ipcbuf_frame_obj_id = capdl_util_make_frame_obj(
@@ -476,16 +481,16 @@ pub fn build_capdl_spec(
     );
     let mon_ipcbuf_frame_cap =
         capdl_util_make_frame_cap(mon_ipcbuf_frame_obj_id, true, true, false, true);
-    map_page(
-        &mut spec_container,
-        kernel_config,
-        MONITOR_PD_NAME,
-        mon_vspace_obj_id,
-        mon_ipcbuf_frame_cap.clone(),
-        PageSize::Small as u64,
-        kernel_config.pd_ipc_buffer(),
-    )
-    .expect("should be able to map the IPC buffer as we checked overlaps in sel4.rs");
+    monitor_elf_spec
+        .address_space
+        .map_page(
+            &mut spec_container,
+            kernel_config,
+            mon_ipcbuf_frame_cap.clone(),
+            PageSize::Small as u64,
+            kernel_config.pd_ipc_buffer(),
+        )
+        .expect("should be able to map the IPC buffer as we checked overlaps in sel4.rs");
 
     // At this point, all of the required objects for the monitor have been created and its caps inserted into
     // the correct slot in the CSpace. We need to bind those objects into the TCB for the monitor to use them.
@@ -628,9 +633,11 @@ pub fn build_capdl_spec(
         let mut caps_to_insert_to_pd_cspace: Vec<CapTableEntry> = Vec::new();
 
         // Step 3-1: Create TCB and VSpace with all ELF loadable frames mapped in.
-        let pd_tcb_obj_id = spec_container
+        let pd_elf_spec = spec_container
             .add_elf_to_spec(kernel_config, &pd.name, pd.cpu, pd_global_idx, elf_obj)
             .unwrap();
+
+        let pd_tcb_obj_id = pd_elf_spec.tcb;
         let pd_vspace_obj_id = capdl_util_get_vspace_id_from_tcb_id(&spec_container, pd_tcb_obj_id);
 
         // In the benchmark configuration, we allow PDs to access their own TCB.
@@ -676,12 +683,11 @@ pub fn build_capdl_spec(
             map_memory_region(
                 &mut spec_container,
                 kernel_config,
-                &pd.name,
                 map,
                 page_size_bytes,
-                pd_vspace_obj_id,
+                &pd_elf_spec.address_space,
                 frames,
-            );
+            )?;
         }
 
         // Step 3-3a: Create and map in the IPC buffer
@@ -694,16 +700,16 @@ pub fn build_capdl_spec(
         );
         let ipcbuf_frame_cap =
             capdl_util_make_frame_cap(ipcbuf_frame_obj_id, true, true, false, true);
-        map_page(
-            &mut spec_container,
-            kernel_config,
-            &pd.name,
-            pd_vspace_obj_id,
-            ipcbuf_frame_cap.clone(),
-            PageSize::Small as u64,
-            kernel_config.pd_ipc_buffer(),
-        )
-        .expect("should be able to map the IPC buffer as we checked overlaps in sel4.rs");
+        pd_elf_spec
+            .address_space
+            .map_page(
+                &mut spec_container,
+                kernel_config,
+                ipcbuf_frame_cap.clone(),
+                PageSize::Small as u64,
+                kernel_config.pd_ipc_buffer(),
+            )
+            .expect("should be able to map the IPC buffer as we checked overlaps in sel4.rs");
         caps_to_bind_to_tcb.push(capdl_util_make_cte(
             TcbBoundSlot::IpcBuffer as u32,
             ipcbuf_frame_cap,
@@ -725,16 +731,16 @@ pub fn build_capdl_spec(
             );
             let stack_frame_cap =
                 capdl_util_make_frame_cap(stack_frame_obj_id, true, true, false, true);
-            map_page(
-                &mut spec_container,
-                kernel_config,
-                &pd.name,
-                pd_vspace_obj_id,
-                stack_frame_cap,
-                PageSize::Small as u64,
-                cur_stack_vaddr,
-            )
-            .unwrap();
+            pd_elf_spec
+                .address_space
+                .map_page(
+                    &mut spec_container,
+                    kernel_config,
+                    stack_frame_cap,
+                    PageSize::Small as u64,
+                    cur_stack_vaddr,
+                )
+                .unwrap();
             cur_stack_vaddr += PageSize::Small as u64;
         }
 
@@ -867,12 +873,13 @@ pub fn build_capdl_spec(
 
             // Create VM's Address Space and map in all memory regions.
             // This address space is shared across all vCPUs. The virtual address that we "map" the region is guest-physical.
-            let vm_vspace_obj_id = match kernel_config.arch {
+            let vm_address_space = match kernel_config.arch {
                 Arch::X86_64 => {
                     create_vspace_ept(&mut spec_container, kernel_config, &virtual_machine.name)
                 }
                 _ => create_vspace(&mut spec_container, kernel_config, &virtual_machine.name),
             };
+            let vm_vspace_obj_id = vm_address_space.root();
             let vm_vspace_cap = capdl_util_make_page_table_cap(vm_vspace_obj_id);
             for map in virtual_machine.maps.iter() {
                 let frames = &mr_name_to_frames[&map.mr];
@@ -881,12 +888,11 @@ pub fn build_capdl_spec(
                 map_memory_region(
                     &mut spec_container,
                     kernel_config,
-                    &virtual_machine.name,
                     map,
                     page_size_bytes,
-                    vm_vspace_obj_id,
+                    &vm_address_space,
                     frames,
-                );
+                )?;
             }
 
             if kernel_config.arch == Arch::X86_64 {

--- a/tool/microkit/src/capdl/irq.rs
+++ b/tool/microkit/src/capdl/irq.rs
@@ -86,18 +86,14 @@ fn create_irq_obj(
             }),
         }),
         SysIrqKind::MSI {
-            pci_bus,
-            pci_dev,
-            pci_func,
-            handle,
-            ..
+            pci_device, handle, ..
         } => Object::IrqMsi(object::IrqMsi {
             slots: [].to_vec(),
             extra: Box::new(object::IrqMsiExtraInfo {
                 handle: Word(handle),
-                pci_bus: Word(pci_bus),
-                pci_dev: Word(pci_dev),
-                pci_func: Word(pci_func),
+                pci_bus: Word(pci_device.bus as u64),
+                pci_dev: Word(pci_device.device as u64),
+                pci_func: Word(pci_device.function as u64),
             }),
         }),
     };

--- a/tool/microkit/src/capdl/memory.rs
+++ b/tool/microkit/src/capdl/memory.rs
@@ -8,7 +8,7 @@ use crate::{
         spec::capdl_obj_human_name, util::capdl_util_make_cte, CapDLNamedObject,
         CapDLSpecContainer, FrameFill,
     },
-    sel4::{Arch, Config, PageSize},
+    sel4::{Arch, Config, ObjectType, PageSize},
 };
 use sel4_capdl_initializer_types::{cap, object, Cap, Object, ObjectId};
 use std::ops::Range;
@@ -81,7 +81,7 @@ impl AddressSpace {
             spec_container,
             sel4_config,
             self.root(),
-            Self::get_root_level(sel4_config),
+            self.get_root_level(sel4_config),
             frame_cap,
             frame_size_bytes,
             addr,
@@ -114,40 +114,39 @@ impl AddressSpace {
         }
     }
 
+    fn get_leaf_bits(&self, sel4_config: &Config) -> u64 {
+        match self {
+            Self::VSpace { .. } => ObjectType::SmallPage.fixed_size_bits(sel4_config).unwrap(),
+        }
+    }
+
+    fn level_index_bits(&self, sel4_config: &Config, level: usize) -> u64 {
+        match self {
+            Self::VSpace { .. } => sel4_config.vspace_level_index_bits(level),
+        }
+    }
+
     fn get_level_index(&self, sel4_config: &Config, level: usize, vaddr: u64) -> usize {
         let levels = self.address_space_levels(sel4_config);
-
         assert!(level < levels);
 
-        let index_bits = |level: usize| -> u64 {
-            if matches!(self, AddressSpace::VSpace { .. })
-                && level == Self::get_root_level(sel4_config)
-                && sel4_config.arch == Arch::Aarch64
-                && sel4_config.aarch64_vspace_s2_start_l1()
-            {
-                // Special case for first level on AArch64 platforms with hyp and 40 bits PA.
-                // It have 10 bits index for VSpace.
-                // match up with seL4_VSpaceBits in seL4/libsel4/sel4_arch_include/aarch64/sel4/sel4_arch/constants.h
-                10
-            } else {
-                9
-            }
-        };
-
-        let page_bits = 12;
-        let bits_from_higher_lvls: u64 = ((level + 1)..levels).map(index_bits).sum();
+        let page_bits = self.get_leaf_bits(sel4_config);
+        let bits_from_higher_lvls: u64 = ((level + 1)..levels)
+            .map(|level| self.level_index_bits(sel4_config, level))
+            .sum();
         let shift = page_bits + bits_from_higher_lvls;
-        let width = index_bits(level);
+        let width = self.level_index_bits(sel4_config, level);
         let mask = (1u64 << width) - 1;
 
         ((vaddr >> shift) & mask) as usize
     }
 
     fn get_level_coverage(&self, sel4_config: &Config, level: usize, vaddr: u64) -> Range<u64> {
-        let levels = self.address_space_levels(sel4_config) as u64;
-
-        let page_bits = 12;
-        let bits_from_higher_lvls: u64 = (levels - (level as u64)) * 9;
+        let levels = self.address_space_levels(sel4_config);
+        let page_bits = self.get_leaf_bits(sel4_config);
+        let bits_from_higher_lvls: u64 = ((level + 1)..levels)
+            .map(|level| self.level_index_bits(sel4_config, level))
+            .sum();
 
         let coverage_bits = page_bits + bits_from_higher_lvls;
 
@@ -347,11 +346,9 @@ impl AddressSpace {
         }
     }
 
-    fn get_root_level(sel4_config: &Config) -> usize {
-        if sel4_config.arch == Arch::Aarch64 && sel4_config.aarch64_vspace_s2_start_l1() {
-            1
-        } else {
-            0
+    fn get_root_level(&self, sel4_config: &Config) -> usize {
+        match self {
+            AddressSpace::VSpace { .. } => sel4_config.vspace_root_level(),
         }
     }
 }
@@ -362,7 +359,7 @@ fn create_vspace_address_space(
     name: &str,
     x86_ept: bool,
 ) -> AddressSpace {
-    let root_level = AddressSpace::get_root_level(sel4_config);
+    let root_level = sel4_config.vspace_root_level();
 
     let root = spec_container.add_root_object(CapDLNamedObject {
         name: format!("{}_{}", get_pt_level_name(sel4_config, root_level), name).into(),

--- a/tool/microkit/src/capdl/memory.rs
+++ b/tool/microkit/src/capdl/memory.rs
@@ -4,7 +4,10 @@
 // SPDX-License-Identifier: BSD-2-Clause
 //
 use crate::{
-    capdl::{util::capdl_util_make_cte, CapDLNamedObject, CapDLSpecContainer},
+    capdl::{
+        spec::capdl_obj_human_name, util::capdl_util_make_cte, CapDLNamedObject,
+        CapDLSpecContainer, FrameFill,
+    },
     sel4::{Arch, Config, PageSize},
 };
 use sel4_capdl_initializer_types::{cap, object, Cap, Object, ObjectId};
@@ -45,174 +48,336 @@ fn get_pt_level_name(sel4_config: &Config, level: usize) -> &str {
     }
 }
 
-fn get_pt_level_index(sel4_config: &Config, level: usize, vaddr: u64) -> usize {
-    let levels = sel4_config.num_page_table_levels();
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AddressSpace {
+    VSpace {
+        name: String,
+        root: ObjectId,
+        x86_ept: bool,
+    },
+}
 
-    assert!(level < levels);
-
-    let index_bits = |level: usize| -> u64 {
-        if level == top_pt_level_number(sel4_config)
-            && sel4_config.arch == Arch::Aarch64
-            && sel4_config.aarch64_vspace_s2_start_l1()
-        {
-            // Special case for first level on AArch64 platforms with hyp and 40 bits PA.
-            // It have 10 bits index for VSpace.
-            // match up with seL4_VSpaceBits in seL4/libsel4/sel4_arch_include/aarch64/sel4/sel4_arch/constants.h
-            10
-        } else {
-            9
+impl AddressSpace {
+    pub fn root(&self) -> ObjectId {
+        match self {
+            &Self::VSpace { root, .. } => root,
         }
-    };
+    }
+    pub fn name(&self) -> &str {
+        match self {
+            Self::VSpace { name, .. } => name,
+        }
+    }
 
-    let page_bits = 12;
-    let bits_from_higher_lvls: u64 = ((level + 1)..levels).map(index_bits).sum();
-    let shift = page_bits + bits_from_higher_lvls;
-    let width = index_bits(level);
-    let mask = (1u64 << width) - 1;
+    pub fn map_page(
+        &self,
+        spec_container: &mut CapDLSpecContainer,
+        sel4_config: &Config,
+        frame_cap: Cap,
+        frame_size_bytes: u64,
+        addr: u64,
+    ) -> Result<(), String> {
+        self.map_recursive(
+            spec_container,
+            sel4_config,
+            self.root(),
+            Self::get_root_level(sel4_config),
+            frame_cap,
+            frame_size_bytes,
+            addr,
+        )
+    }
 
-    ((vaddr >> shift) & mask) as usize
-}
+    fn get_leaf_level(&self, sel4_config: &Config, page_size_bytes: u64) -> usize {
+        const SMALL_PAGE_BYTES: u64 = PageSize::Small as u64;
+        const LARGE_PAGE_BYTES: u64 = PageSize::Large as u64;
+        let levels = self.address_space_levels(sel4_config);
 
-fn get_pt_level_coverage(sel4_config: &Config, level: usize, vaddr: u64) -> Range<u64> {
-    let levels = sel4_config.num_page_table_levels() as u64;
-    let page_bits = 12;
-    let bits_from_higher_lvls: u64 = (levels - (level as u64)) * 9;
-
-    let coverage_bits = page_bits + bits_from_higher_lvls;
-
-    let low = (vaddr >> coverage_bits) << coverage_bits;
-    let high = vaddr | ((1 << coverage_bits) - 1);
-
-    low..high
-}
-
-fn get_pt_level_to_insert(sel4_config: &Config, page_size_bytes: u64) -> usize {
-    const SMALL_PAGE_BYTES: u64 = PageSize::Small as u64;
-    const LARGE_PAGE_BYTES: u64 = PageSize::Large as u64;
-    match page_size_bytes {
-        SMALL_PAGE_BYTES => sel4_config.num_page_table_levels() - 1,
-        LARGE_PAGE_BYTES => sel4_config.num_page_table_levels() - 2,
-        _ => unreachable!(
+        match page_size_bytes {
+            SMALL_PAGE_BYTES => levels - 1,
+            LARGE_PAGE_BYTES => levels - 2,
+            _ => unreachable!(
             "internal bug: get_pt_level_to_insert(): unknown page_size_bytes: {page_size_bytes}"
         ),
+        }
     }
-}
 
-fn top_pt_level_number(sel4_config: &Config) -> usize {
-    if sel4_config.arch == Arch::Aarch64 && sel4_config.aarch64_vspace_s2_start_l1() {
-        1
-    } else {
-        0
+    fn get_level_name(&self, sel4_config: &Config, level: usize) -> String {
+        match self {
+            Self::VSpace { .. } => get_pt_level_name(sel4_config, level).to_string(),
+        }
     }
-}
 
-fn insert_cap_into_page_table_level(
-    spec_container: &mut CapDLSpecContainer,
-    cur_level_obj_id: ObjectId,
-    cur_level: usize,
-    cur_level_slot: usize,
-    cap: Cap,
-) -> Result<(), String> {
-    let page_table_level_obj_wrapper = spec_container
-        .get_root_object_mut(cur_level_obj_id)
-        .unwrap();
-    if let Object::PageTable(page_table_object) = &mut page_table_level_obj_wrapper.object {
-        // Sanity check that this slot is free
-        match page_table_object
-            .slots
+    fn get_addr_label(&self) -> &'static str {
+        match self {
+            Self::VSpace { .. } => "vaddr",
+        }
+    }
+
+    fn get_level_index(&self, sel4_config: &Config, level: usize, vaddr: u64) -> usize {
+        let levels = self.address_space_levels(sel4_config);
+
+        assert!(level < levels);
+
+        let index_bits = |level: usize| -> u64 {
+            if matches!(self, AddressSpace::VSpace { .. })
+                && level == Self::get_root_level(sel4_config)
+                && sel4_config.arch == Arch::Aarch64
+                && sel4_config.aarch64_vspace_s2_start_l1()
+            {
+                // Special case for first level on AArch64 platforms with hyp and 40 bits PA.
+                // It have 10 bits index for VSpace.
+                // match up with seL4_VSpaceBits in seL4/libsel4/sel4_arch_include/aarch64/sel4/sel4_arch/constants.h
+                10
+            } else {
+                9
+            }
+        };
+
+        let page_bits = 12;
+        let bits_from_higher_lvls: u64 = ((level + 1)..levels).map(index_bits).sum();
+        let shift = page_bits + bits_from_higher_lvls;
+        let width = index_bits(level);
+        let mask = (1u64 << width) - 1;
+
+        ((vaddr >> shift) & mask) as usize
+    }
+
+    fn get_level_coverage(&self, sel4_config: &Config, level: usize, vaddr: u64) -> Range<u64> {
+        let levels = self.address_space_levels(sel4_config) as u64;
+
+        let page_bits = 12;
+        let bits_from_higher_lvls: u64 = (levels - (level as u64)) * 9;
+
+        let coverage_bits = page_bits + bits_from_higher_lvls;
+
+        let low = (vaddr >> coverage_bits) << coverage_bits;
+        let high = vaddr | ((1 << coverage_bits) - 1);
+
+        low..high
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn map_recursive(
+        &self,
+        spec_container: &mut CapDLSpecContainer,
+        sel4_config: &Config,
+        cur_level_obj_id: ObjectId,
+        cur_level: usize,
+        frame_cap: Cap,
+        frame_size_bytes: u64,
+        addr: u64,
+    ) -> Result<(), String> {
+        if cur_level >= self.address_space_levels(sel4_config) {
+            unreachable!("internal bug: recursed past the final address-space level");
+        }
+
+        let slot = self.get_level_index(sel4_config, cur_level, addr);
+        let leaf_level = self.get_leaf_level(sel4_config, frame_size_bytes);
+
+        if cur_level == leaf_level {
+            self.insert_cap_into_level(
+                spec_container,
+                sel4_config,
+                cur_level_obj_id,
+                cur_level,
+                slot,
+                frame_cap,
+            )
+        } else {
+            let next_obj_id = self.map_intermediary_level_helper(
+                spec_container,
+                sel4_config,
+                cur_level_obj_id,
+                cur_level,
+                slot,
+                addr,
+            )?;
+            self.map_recursive(
+                spec_container,
+                sel4_config,
+                next_obj_id,
+                cur_level + 1,
+                frame_cap,
+                frame_size_bytes,
+                addr,
+            )
+        }
+    }
+
+    fn map_intermediary_level_helper(
+        &self,
+        spec_container: &mut CapDLSpecContainer,
+        sel4_config: &Config,
+        cur_level_obj_id: ObjectId,
+        cur_level: usize,
+        cur_level_slot: usize,
+        addr: u64,
+    ) -> Result<ObjectId, String> {
+        let object = &spec_container
+            .get_root_object(cur_level_obj_id)
+            .unwrap()
+            .object;
+
+        self.valid_level_object(object, sel4_config, cur_level)?;
+        let slots = object.slots().unwrap();
+
+        if let Some(child_obj_id) = slots
             .iter()
             .find(|cte| usize::from(cte.slot) == cur_level_slot)
+            .map(|cte| cte.cap.obj())
         {
-            Some(_) => Err(format!(
-                "insert_cap_into_page_table_level(): internal bug: slot {} at PT level {} with name '{}' already filled",
-                cur_level_slot, cur_level, spec_container.get_root_object(cur_level_obj_id).unwrap().name.as_ref().unwrap()
-            )),
-            None => {
-                page_table_object.slots.push(capdl_util_make_cte(cur_level_slot as u32, cap));
-                Ok(())
-            }
+            return Ok(child_obj_id);
         }
-    } else {
-        Err(format!(
-            "insert_cap_into_page_table_level(): internal bug: received a non-Page Table object id {} with name '{}'",
-            usize::from(cur_level_obj_id), spec_container.get_root_object(cur_level_obj_id).unwrap().name.as_ref().unwrap()
-        ))
+
+        let next_level = cur_level + 1;
+        let next_level_coverage = self.get_level_coverage(sel4_config, next_level, addr);
+        let next_level_obj = CapDLNamedObject {
+            name: self
+                .object_name(sel4_config, next_level, next_level_coverage.start)
+                .into(),
+            object: self.make_intermediate_object(next_level),
+        };
+        let next_obj_id = spec_container.add_root_object(next_level_obj);
+        let next_cap = self.make_intermediate_cap(next_obj_id);
+
+        self.insert_cap_into_level(
+            spec_container,
+            sel4_config,
+            cur_level_obj_id,
+            cur_level,
+            cur_level_slot,
+            next_cap,
+        )?;
+
+        Ok(next_obj_id)
+    }
+
+    fn insert_cap_into_level(
+        &self,
+        spec_container: &mut CapDLSpecContainer,
+        sel4_config: &Config,
+        cur_level_obj_id: ObjectId,
+        cur_level: usize,
+        cur_level_slot: usize,
+        cap: Cap,
+    ) -> Result<(), String> {
+        let object = &mut spec_container
+            .get_root_object_mut(cur_level_obj_id)
+            .unwrap()
+            .object;
+
+        self.valid_level_object(object, sel4_config, cur_level)?;
+
+        let slots = object.slots_mut().unwrap();
+
+        if slots
+            .iter()
+            .any(|cte| usize::from(cte.slot) == cur_level_slot)
+        {
+            Err(format!(
+                "address-space '{}': slot {} at level {} in object '{}' is already filled",
+                self.name(),
+                cur_level_slot,
+                cur_level,
+                spec_container
+                    .get_root_object(cur_level_obj_id)
+                    .unwrap()
+                    .name
+                    .as_ref()
+                    .unwrap()
+            ))
+        } else {
+            slots.push(capdl_util_make_cte(cur_level_slot as u32, cap));
+            Ok(())
+        }
+    }
+
+    fn make_intermediate_object(&self, level: usize) -> Object<FrameFill> {
+        match self {
+            &AddressSpace::VSpace { x86_ept, .. } => Object::PageTable(object::PageTable {
+                x86_ept,
+                is_root: false,
+                level: Some(level as u8),
+                slots: vec![],
+            }),
+        }
+    }
+
+    fn make_intermediate_cap(&self, object: ObjectId) -> Cap {
+        match self {
+            AddressSpace::VSpace { .. } => Cap::PageTable(cap::PageTable { object }),
+        }
+    }
+
+    fn object_name(&self, sel4_config: &Config, level: usize, coverage_start: u64) -> String {
+        format!(
+            "{}_{}_{}_{:#x}",
+            self.get_level_name(sel4_config, level),
+            self.name(),
+            self.get_addr_label(),
+            coverage_start
+        )
+    }
+
+    fn valid_level_object(
+        &self,
+        object: &Object<FrameFill>,
+        sel4_config: &Config,
+        cur_level: usize,
+    ) -> Result<(), String> {
+        let valid = match self {
+            AddressSpace::VSpace { .. } => matches!(object, Object::PageTable(_)),
+        };
+        if valid {
+            Ok(())
+        } else {
+            Err(format!(
+                "Error: found an invalid object {} at level {} in address-space {}!",
+                capdl_obj_human_name(object, sel4_config),
+                cur_level,
+                self.name()
+            ))
+        }
+    }
+
+    fn address_space_levels(&self, sel4_config: &Config) -> usize {
+        match self {
+            AddressSpace::VSpace { .. } => sel4_config.num_page_table_levels(),
+        }
+    }
+
+    fn get_root_level(sel4_config: &Config) -> usize {
+        if sel4_config.arch == Arch::Aarch64 && sel4_config.aarch64_vspace_s2_start_l1() {
+            1
+        } else {
+            0
+        }
     }
 }
 
-// Just this one time pinky promise
-#[allow(clippy::too_many_arguments)]
-fn map_intermediary_level_helper(
+fn create_vspace_address_space(
     spec_container: &mut CapDLSpecContainer,
     sel4_config: &Config,
-    pd_name: &str,
-    next_level_name_prefix: &str,
-    vspace_obj_id: ObjectId,
-    cur_level_obj_id: ObjectId,
-    cur_level: usize,
-    cur_level_slot: usize,
-    vaddr: u64,
-) -> Result<ObjectId, String> {
-    let page_table_level_obj_wrapper = spec_container.get_root_object(cur_level_obj_id).unwrap();
-    if let Object::PageTable(page_table_object) = &page_table_level_obj_wrapper.object {
-        match page_table_object
-            .slots
-            .iter()
-            .find(|cte| usize::from(cte.slot) == cur_level_slot)
-        {
-            Some(cte_unwrapped) => {
-                // Next level object already created, nothing to do here
-                return Ok(cte_unwrapped.cap.obj());
-            }
-            None => {
-                // We need to create the next level paging structure, get out of this scope for now
-                // so we don't get a double mutable borrow of spec when we need to insert the next level object
-            }
-        }
-    } else {
-        return Err(format!("map_intermediary_level_helper(): internal bug: received a non-Page Table object id {} with name '{}', for mapping at level {}, to pd {}.",
-            usize::from(cur_level_obj_id), spec_container.get_root_object(cur_level_obj_id).unwrap().name.as_ref().unwrap(), cur_level, pd_name));
-    }
+    name: &str,
+    x86_ept: bool,
+) -> AddressSpace {
+    let root_level = AddressSpace::get_root_level(sel4_config);
 
-    // Next level object not already created, create it.
-    let vspace_obj = match &spec_container.get_root_object(vspace_obj_id).unwrap().object {
-        Object::PageTable(o) => o,
-        _ => unreachable!(
-            "map_intermediary_level_helper(): internal bug: received a non VSpace object id {} with name '{}'",
-            usize::from(vspace_obj_id), spec_container.get_root_object(vspace_obj_id).unwrap().name.as_ref().unwrap()
-        ),
-    };
-    let next_level_coverage = get_pt_level_coverage(sel4_config, cur_level + 1, vaddr);
-    let next_level_inner_obj = object::PageTable {
-        x86_ept: vspace_obj.x86_ept,
-        is_root: false, // because the VSpace has already been created separately
-        level: Some(cur_level as u8 + 1),
-        slots: [].to_vec(),
-    };
-    // We create name with this PT level coverage so that every object names are unique
-    let next_level_object = CapDLNamedObject {
-        name: format!(
-            "{}_{}_vaddr_0x{:x}",
-            next_level_name_prefix, pd_name, next_level_coverage.start
-        )
-        .into(),
-        object: Object::PageTable(next_level_inner_obj),
-    };
-    let next_level_obj_id = spec_container.add_root_object(next_level_object);
-    let next_level_cap = Cap::PageTable(cap::PageTable {
-        object: next_level_obj_id,
+    let root = spec_container.add_root_object(CapDLNamedObject {
+        name: format!("{}_{}", get_pt_level_name(sel4_config, root_level), name).into(),
+        object: Object::PageTable(object::PageTable {
+            x86_ept,
+            is_root: true,
+            level: Some(root_level as u8),
+            slots: vec![],
+        }),
     });
 
-    // Then insert into the correct slot at the current level, return and continue mapping
-    match insert_cap_into_page_table_level(
-        spec_container,
-        cur_level_obj_id,
-        cur_level,
-        cur_level_slot,
-        next_level_cap,
-    ) {
-        Ok(_) => Ok(next_level_obj_id),
-        Err(err_reason) => Err(err_reason),
+    AddressSpace::VSpace {
+        name: name.to_string(),
+        root,
+        x86_ept,
     }
 }
 
@@ -220,116 +385,15 @@ pub fn create_vspace(
     spec_container: &mut CapDLSpecContainer,
     sel4_config: &Config,
     pd_name: &str,
-) -> ObjectId {
-    spec_container.add_root_object(CapDLNamedObject {
-        name: format!(
-            "{}_{}",
-            get_pt_level_name(sel4_config, top_pt_level_number(sel4_config)),
-            pd_name
-        )
-        .into(),
-        object: Object::PageTable(object::PageTable {
-            x86_ept: false,
-            is_root: true,
-            level: Some(top_pt_level_number(sel4_config) as u8),
-            slots: [].to_vec(),
-        }),
-    })
+) -> AddressSpace {
+    create_vspace_address_space(spec_container, sel4_config, pd_name, false)
 }
 
 pub fn create_vspace_ept(
     spec_container: &mut CapDLSpecContainer,
     sel4_config: &Config,
     vm_name: &str,
-) -> ObjectId {
+) -> AddressSpace {
     assert!(sel4_config.arch == Arch::X86_64);
-
-    spec_container.add_root_object(CapDLNamedObject {
-        name: format!("{}_{}", get_pt_level_name(sel4_config, 0), vm_name).into(),
-        object: Object::PageTable(object::PageTable {
-            x86_ept: true,
-            is_root: true,
-            level: Some(top_pt_level_number(sel4_config) as u8),
-            slots: [].to_vec(),
-        }),
-    })
-}
-
-#[allow(clippy::too_many_arguments)]
-fn map_recursive(
-    spec_container: &mut CapDLSpecContainer,
-    sel4_config: &Config,
-    pd_name: &str,
-    vspace_obj_id: ObjectId,
-    pt_obj_id: ObjectId,
-    cur_level: usize,
-    frame_cap: Cap,
-    frame_size_bytes: u64,
-    vaddr: u64,
-) -> Result<(), String> {
-    if cur_level >= sel4_config.num_page_table_levels() {
-        unreachable!("internal bug: we should have never recursed further!");
-    }
-
-    let this_level_index = get_pt_level_index(sel4_config, cur_level, vaddr);
-
-    if cur_level == get_pt_level_to_insert(sel4_config, frame_size_bytes) {
-        // Base case: we got to the target level to insert the frame cap.
-        insert_cap_into_page_table_level(
-            spec_container,
-            pt_obj_id,
-            cur_level,
-            this_level_index,
-            frame_cap,
-        )
-    } else {
-        // Recursive case: we have not gotten to the correct level, create the next level and recurse down.
-        let next_level_name_prefix = get_pt_level_name(sel4_config, cur_level + 1);
-        match map_intermediary_level_helper(
-            spec_container,
-            sel4_config,
-            pd_name,
-            next_level_name_prefix,
-            vspace_obj_id,
-            pt_obj_id,
-            cur_level,
-            this_level_index,
-            vaddr,
-        ) {
-            Ok(next_level_pt_obj_id) => map_recursive(
-                spec_container,
-                sel4_config,
-                pd_name,
-                vspace_obj_id,
-                next_level_pt_obj_id,
-                cur_level + 1,
-                frame_cap,
-                frame_size_bytes,
-                vaddr,
-            ),
-            Err(err_reason) => Err(err_reason),
-        }
-    }
-}
-
-pub fn map_page(
-    spec_container: &mut CapDLSpecContainer,
-    sel4_config: &Config,
-    pd_name: &str,
-    vspace_obj_id: ObjectId,
-    frame_cap: Cap,
-    frame_size_bytes: u64,
-    vaddr: u64,
-) -> Result<(), String> {
-    map_recursive(
-        spec_container,
-        sel4_config,
-        pd_name,
-        vspace_obj_id,
-        vspace_obj_id,
-        top_pt_level_number(sel4_config),
-        frame_cap,
-        frame_size_bytes,
-        vaddr,
-    )
+    create_vspace_address_space(spec_container, sel4_config, vm_name, true)
 }

--- a/tool/microkit/src/main.rs
+++ b/tool/microkit/src/main.rs
@@ -227,6 +227,11 @@ fn main() -> Result<(), String> {
         _ => false,
     };
 
+    let iommu = match arch {
+        Arch::X86_64 => json_str_as_bool(&kernel_config_json, "IOMMU")?,
+        _ => false,
+    };
+
     let arm_pa_size_bits = match arch {
         Arch::Aarch64 => {
             if json_str_as_bool(&kernel_config_json, "ARM_PA_SIZE_BITS_40")? {
@@ -265,6 +270,7 @@ fn main() -> Result<(), String> {
             "MAX_NUM_BOOTINFO_UNTYPED_CAPS",
         )?,
         hypervisor,
+        iommu,
         benchmark: args.config == "benchmark",
         num_cores: if json_str_as_bool(&kernel_config_json, "ENABLE_SMP_SUPPORT")? {
             json_str_as_u64(&kernel_config_json, "MAX_NUM_NODES")?

--- a/tool/microkit/src/sdf.rs
+++ b/tool/microkit/src/sdf.rs
@@ -417,7 +417,7 @@ impl SysMap {
             return Err(value_error(
                 xml_sdf,
                 node,
-                format!("vaddr (0x{vaddr:x}) must be less than 0x{max_vaddr:x}"),
+                format!("vaddr ({vaddr:#x}) must be less than {max_vaddr:#x}"),
             ));
         }
 
@@ -633,7 +633,7 @@ impl ProtectionDomain {
                 xml_sdf,
                 node,
                 format!(
-                    "stack size must be between 0x{PD_MIN_STACK_SIZE:x} bytes and 0x{PD_MAX_STACK_SIZE:x} bytes"
+                    "stack size must be between {PD_MIN_STACK_SIZE:#x} bytes and {PD_MAX_STACK_SIZE:#x} bytes"
                 ),
             ));
         }
@@ -1545,7 +1545,7 @@ impl SysMemoryRegion {
             return Err(value_error(
                 xml_sdf,
                 node,
-                format!("page size 0x{page_size:x} not supported"),
+                format!("page size {page_size:#x} not supported"),
             ));
         }
 
@@ -1804,7 +1804,7 @@ fn check_maps(
                     if !(map_start >= *end || map_end <= *start) {
                         return Err(
                             format!(
-                                "Error: map for '{}' has virtual address range [0x{:x}..0x{:x}) which overlaps with map for '{}' [0x{:x}..0x{:x}) in {} '{}' @ {}",
+                                "Error: map for '{}' has virtual address range [{:#x}..{:#x}) which overlaps with map for '{}' [{:#x}..{:#x}) in {} '{}' @ {}",
                                 map.mr,
                                 map_start,
                                 map_end,
@@ -2371,7 +2371,7 @@ pub fn parse(
                     let pos = mr.text_pos.unwrap();
                     return Err(
                         format!(
-                            "Error: memory region '{}' physical address range [0x{:x}..0x{:x}) overlaps with another memory region '{}' [0x{:x}..0x{:x}) @ {}",
+                            "Error: memory region '{}' physical address range [{:#x}..{:#x}) overlaps with another memory region '{}' [{:#x}..{:#x}) @ {}",
                             mr.name,
                             mr_start,
                             mr_end,

--- a/tool/microkit/src/sdf.rs
+++ b/tool/microkit/src/sdf.rs
@@ -306,14 +306,6 @@ impl SysIOMapPerms {
             (false, false) => Err(()),
         }
     }
-
-    pub fn read(self) -> bool {
-        matches!(self, SysIOMapPerms::Read | SysIOMapPerms::ReadWrite)
-    }
-
-    pub fn write(self) -> bool {
-        matches!(self, SysIOMapPerms::Write | SysIOMapPerms::ReadWrite)
-    }
 }
 
 #[derive(Debug, PartialEq, Eq, Clone)]
@@ -327,13 +319,17 @@ pub struct SysIOMap {
     pub text_pos: Option<roxmltree::TextPos>,
 }
 
-trait Map {
+pub trait Map {
     fn mr_name(&self) -> &str;
     fn addr(&self) -> u64;
     fn text_pos(&self) -> Option<roxmltree::TextPos>;
     fn element(&self) -> &'static str;
     fn addr_name(&self) -> &'static str;
     fn range_name(&self) -> &'static str;
+    fn read(&self) -> bool;
+    fn write(&self) -> bool;
+    fn execute(&self) -> bool;
+    fn cached(&self) -> bool;
 }
 
 impl Map for SysMap {
@@ -359,6 +355,22 @@ impl Map for SysMap {
 
     fn range_name(&self) -> &'static str {
         "virtual address range"
+    }
+
+    fn read(&self) -> bool {
+        self.perms & SysMapPerms::Read as u8 != 0
+    }
+
+    fn write(&self) -> bool {
+        self.perms & SysMapPerms::Write as u8 != 0
+    }
+
+    fn execute(&self) -> bool {
+        self.perms & SysMapPerms::Execute as u8 != 0
+    }
+
+    fn cached(&self) -> bool {
+        self.cached
     }
 }
 
@@ -386,7 +398,24 @@ impl Map for SysIOMap {
     fn range_name(&self) -> &'static str {
         "io address range"
     }
+
+    fn read(&self) -> bool {
+        matches!(self.perms, SysIOMapPerms::Read | SysIOMapPerms::ReadWrite)
+    }
+
+    fn write(&self) -> bool {
+        matches!(self.perms, SysIOMapPerms::Write | SysIOMapPerms::ReadWrite)
+    }
+
+    fn execute(&self) -> bool {
+        false
+    }
+
+    fn cached(&self) -> bool {
+        false
+    }
 }
+
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub enum SysMemoryRegionKind {
     User,

--- a/tool/microkit/src/sdf.rs
+++ b/tool/microkit/src/sdf.rs
@@ -321,6 +321,7 @@ pub struct SysIOMap {
     pub device: String,
     pub mr: String,
     pub identifier: IommuDeviceIdentifier,
+    pub domain_id: Option<u64>,
     pub iovaddr: u64,
     pub perms: SysIOMapPerms,
     pub text_pos: Option<roxmltree::TextPos>,
@@ -707,6 +708,7 @@ impl SysIOMap {
         node: &roxmltree::Node,
         device: &str,
         identifier: IommuDeviceIdentifier,
+        domain_id: Option<u64>,
     ) -> Result<SysIOMap, String> {
         let attrs = vec!["mr", "iovaddr", "perms"];
 
@@ -747,6 +749,7 @@ impl SysIOMap {
             device: device.to_string(),
             mr,
             identifier,
+            domain_id,
             iovaddr,
             perms,
             text_pos: Some(xml_sdf.doc.text_pos_at(node.range().start)),
@@ -767,6 +770,7 @@ impl IOAddressSpace {
         xml_sdf: &XmlSystemDescription,
         node: &roxmltree::Node,
         device_names: &mut HashSet<String>,
+        domain_ids: &mut HashSet<u64>,
         iommu_device_identifiers: &mut HashSet<IommuDeviceIdentifier>,
     ) -> Result<IOAddressSpace, String> {
         let pos = xml_sdf.doc.text_pos_at(node.range().start);
@@ -777,7 +781,7 @@ impl IOAddressSpace {
             ));
         }
 
-        check_attributes(xml_sdf, node, &["name", "peripheral_id"])?;
+        check_attributes(xml_sdf, node, &["name", "peripheral_id", "domain_id"])?;
         let device_name = checked_lookup(xml_sdf, node, "name")?;
         if !device_names.insert(device_name.to_string()) {
             return Err(value_error(
@@ -786,6 +790,27 @@ impl IOAddressSpace {
                 format!("duplicate device name '{device_name}'"),
             ));
         }
+
+        // Currently we enforce unqiue domain ids. To support shared domain ids, we have to ensure
+        // each device has a duplicated copy of the whole page table structure due to how Intel
+        // implements IOMMU caching see section 6.2.1 in the Virtualization Technology (Intel® VT) for Directed I/O
+        // (Intel® VT-d) manual:
+        // http://www.intel.com/content/dam/www/public/us/en/documents/product-specifications/vt-directed-io-spec.pdf
+        let domain_id = match config.arch {
+            Arch::X86_64 => {
+                let domain_id =
+                    sdf_parse_number(checked_lookup(xml_sdf, node, "domain_id")?, node)?;
+                if !domain_ids.insert(domain_id) {
+                    return Err(value_error(
+                        xml_sdf,
+                        node,
+                        "reusing a domain id is forbidden".into(),
+                    ));
+                }
+                Some(domain_id)
+            }
+            _ => None,
+        };
 
         // In the SDF we use peripheral_id as an architecture agnostic way to describe
         // how a device is identified in a system. For example on x86 the IOMMU identifies
@@ -812,8 +837,14 @@ impl IOAddressSpace {
         for child in node.children().filter(|node| node.is_element()) {
             match child.tag_name().name() {
                 "iomap" => {
-                    let iomap =
-                        SysIOMap::from_xml(config, xml_sdf, &child, device_name, identifier)?;
+                    let iomap = SysIOMap::from_xml(
+                        config,
+                        xml_sdf,
+                        &child,
+                        device_name,
+                        identifier,
+                        domain_id,
+                    )?;
                     iomaps.push(iomap);
                 }
                 _ => {
@@ -2336,6 +2367,7 @@ pub fn parse(
     let mut mrs = vec![];
     let mut iomaps = vec![];
     let mut device_names = HashSet::new();
+    let mut domain_ids = HashSet::new();
     let mut iommu_device_identifiers = HashSet::new();
     let mut channels = vec![];
     let system = doc
@@ -2376,6 +2408,7 @@ pub fn parse(
                         &xml_sdf,
                         &child,
                         &mut device_names,
+                        &mut domain_ids,
                         &mut iommu_device_identifiers,
                     )?
                     .iomaps,

--- a/tool/microkit/src/sdf.rs
+++ b/tool/microkit/src/sdf.rs
@@ -24,9 +24,10 @@ use crate::util::{get_full_path, ranges_overlap, round_up, str_to_bool};
 use crate::MAX_PDS;
 use sel4_capdl_initializer_types::FillEntryContentBootInfoId;
 use std::collections::{HashMap, HashSet};
-use std::fmt::Display;
+use std::fmt;
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::str::FromStr;
 
 /// Events that come through entry points (e.g notified or protected) are given an
 /// identifier that is used as the badge at runtime.
@@ -55,11 +56,6 @@ pub const MONITOR_PD_NAME: &str = "monitor";
 pub const PD_DEFAULT_STACK_SIZE: u64 = 0x2000;
 const PD_MIN_STACK_SIZE: u64 = 0x1000;
 const PD_MAX_STACK_SIZE: u64 = 1024 * 1024 * 16;
-
-/// Maximum values for PCI bus, device, function numbers. Inclusive.
-const PCI_BUS_MAX: i64 = (1 << 8) - 1;
-const PCI_DEV_MAX: i64 = (1 << 5) - 1;
-const PCI_FUNC_MAX: i64 = (1 << 3) - 1;
 
 /// Maximum x86 IRQ vector value. Inclusive.
 /// This value is calculated by the kernel as `irq_user_max - irq_user_min` in
@@ -95,6 +91,105 @@ fn loc_string(xml_sdf: &XmlSystemDescription, pos: roxmltree::TextPos) -> String
     format!("{}:{}:{}", xml_sdf.filename.display(), pos.row, pos.col)
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct PciDevice {
+    pub bus: u8,
+    pub device: u8,
+    pub function: u8,
+}
+
+impl PciDevice {
+    /// Maximum values for PCI bus, device, function numbers. Inclusive.
+    const PCI_BUS_MAX: i64 = (1 << 8) - 1;
+    const PCI_DEV_MAX: i64 = (1 << 5) - 1;
+    const PCI_FUNC_MAX: i64 = (1 << 3) - 1;
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PciDeviceParseError {
+    Malformed,
+    BusParse,
+    DeviceParse,
+    FunctionParse,
+    BusOutOfRange,
+    DeviceOutOfRange,
+    FunctionOutOfRange,
+}
+
+impl fmt::Display for PciDevice {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{:02x}:{:02x}.{:x}",
+            self.bus, self.device, self.function
+        )
+    }
+}
+
+impl fmt::Display for PciDeviceParseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            PciDeviceParseError::Malformed => {
+                write!(f, "expected PCI address in bus:device.function form")
+            }
+            PciDeviceParseError::BusParse => write!(f, "failed to parse PCI bus"),
+            PciDeviceParseError::DeviceParse => write!(f, "failed to parse PCI device"),
+            PciDeviceParseError::FunctionParse => write!(f, "failed to parse PCI function"),
+            PciDeviceParseError::BusOutOfRange => {
+                write!(f, "PCI bus must be within [0..{}]", PciDevice::PCI_BUS_MAX)
+            }
+            PciDeviceParseError::DeviceOutOfRange => {
+                write!(
+                    f,
+                    "PCI device must be within [0..{}]",
+                    PciDevice::PCI_DEV_MAX
+                )
+            }
+            PciDeviceParseError::FunctionOutOfRange => {
+                write!(
+                    f,
+                    "PCI function must be within [0..{}]",
+                    PciDevice::PCI_FUNC_MAX
+                )
+            }
+        }
+    }
+}
+
+impl FromStr for PciDevice {
+    type Err = PciDeviceParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let (bus_str, device_function_str) =
+            s.split_once(':').ok_or(PciDeviceParseError::Malformed)?;
+        let (device_str, function_str) = device_function_str
+            .split_once('.')
+            .ok_or(PciDeviceParseError::Malformed)?;
+
+        let bus =
+            i64::from_str_radix(bus_str.trim(), 16).map_err(|_| PciDeviceParseError::BusParse)?;
+        let device = i64::from_str_radix(device_str.trim(), 16)
+            .map_err(|_| PciDeviceParseError::DeviceParse)?;
+        let function = i64::from_str_radix(function_str.trim(), 16)
+            .map_err(|_| PciDeviceParseError::FunctionParse)?;
+
+        if !(0..=PciDevice::PCI_BUS_MAX).contains(&bus) {
+            return Err(PciDeviceParseError::BusOutOfRange);
+        }
+        if !(0..=PciDevice::PCI_DEV_MAX).contains(&device) {
+            return Err(PciDeviceParseError::DeviceOutOfRange);
+        }
+        if !(0..=PciDevice::PCI_FUNC_MAX).contains(&function) {
+            return Err(PciDeviceParseError::FunctionOutOfRange);
+        }
+
+        Ok(PciDevice {
+            bus: bus as u8,
+            device: device as u8,
+            function: function as u8,
+        })
+    }
+}
 #[repr(u8)]
 pub enum SysMapPerms {
     Read = 1,
@@ -224,9 +319,7 @@ pub enum SysIrqKind {
     },
     /// x86-64 specific
     MSI {
-        pci_bus: u64,
-        pci_dev: u64,
-        pci_func: u64,
+        pci_device: PciDevice,
         handle: u64,
         vector: u64,
     },
@@ -293,7 +386,7 @@ pub struct Channel {
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct CpuCore(pub u8);
 
-impl Display for CpuCore {
+impl fmt::Display for CpuCore {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.write_fmt(format_args!("cpu{:02}", self.0))
     }
@@ -907,94 +1000,8 @@ impl ProtectionDomain {
                             &["id", "setvar_id", "pcidev", "handle", "vector"],
                         )?;
 
-                        // A "pcidev" attribute is in a form of Bus:Dev.Func
-                        // Split by the colon then the dot.
-
-                        // If the input is valid, index 0 contains "Bus", index 1 contains
-                        // "Dev.Func"
-                        let pci_parts_by_colon: Vec<_> =
-                            pcidev_str.split(':').map(str::trim).collect();
-
-                        if pci_parts_by_colon.len() != 2 {
-                            return Err(format!(
-                                "Error: failed to parse PCI address '{}' on element '{}'",
-                                pcidev_str,
-                                child.tag_name().name()
-                            ));
-                        }
-
-                        // If the input is valid, index 0 contains "Dev", index 1 contains
-                        // "Func"
-                        let pci_parts_by_dot: Vec<_> =
-                            pci_parts_by_colon[1].split('.').map(str::trim).collect();
-                        if pci_parts_by_dot.len() != 2 {
-                            return Err(format!(
-                                "Error: failed to parse PCI address '{}' on element '{}'",
-                                pcidev_str,
-                                child.tag_name().name()
-                            ));
-                        }
-
-                        let pci_bus_maybe = i64::from_str_radix(pci_parts_by_colon[0], 16);
-                        let pci_dev_maybe = i64::from_str_radix(pci_parts_by_dot[0], 16);
-                        let pci_func_maybe = i64::from_str_radix(pci_parts_by_dot[1], 16);
-
-                        match pci_bus_maybe {
-                            Ok(pci_bus_unchecked) => {
-                                if !(0..=PCI_BUS_MAX).contains(&pci_bus_unchecked) {
-                                    return Err(value_error(
-                                        xml_sdf,
-                                        &child,
-                                        format!("PCI bus must be within [0..{PCI_BUS_MAX}]"),
-                                    ));
-                                }
-                            }
-                            Err(_) => {
-                                return Err(format!(
-                                    "Error: failed to parse PCI bus of '{}' on element '{}'",
-                                    pcidev_str,
-                                    child.tag_name().name()
-                                ))
-                            }
-                        };
-
-                        match pci_dev_maybe {
-                            Ok(pci_dev_unchecked) => {
-                                if !(0..=PCI_DEV_MAX).contains(&pci_dev_unchecked) {
-                                    return Err(value_error(
-                                        xml_sdf,
-                                        &child,
-                                        format!("PCI device must be within [0..{PCI_DEV_MAX}]"),
-                                    ));
-                                }
-                            }
-                            Err(_) => {
-                                return Err(format!(
-                                    "Error: failed to parse PCI device of '{}' on element '{}'",
-                                    pcidev_str,
-                                    child.tag_name().name()
-                                ))
-                            }
-                        };
-
-                        match pci_func_maybe {
-                            Ok(pci_func_unchecked) => {
-                                if !(0..=PCI_FUNC_MAX).contains(&pci_func_unchecked) {
-                                    return Err(value_error(
-                                        xml_sdf,
-                                        &child,
-                                        format!("PCI function must be within [0..{PCI_FUNC_MAX}]"),
-                                    ));
-                                }
-                            }
-                            Err(_) => {
-                                return Err(format!(
-                                    "Error: failed to parse PCI function of '{}' on element '{}'",
-                                    pcidev_str,
-                                    child.tag_name().name()
-                                ))
-                            }
-                        };
+                        let pci_device = PciDevice::from_str(pcidev_str)
+                            .map_err(|err| value_error(xml_sdf, &child, err.to_string()))?;
 
                         let handle = checked_lookup(xml_sdf, &child, "handle")?
                             .parse::<i64>()
@@ -1021,9 +1028,7 @@ impl ProtectionDomain {
                         let irq = SysIrq {
                             id: id as u64,
                             kind: SysIrqKind::MSI {
-                                pci_bus: pci_bus_maybe.unwrap() as u64,
-                                pci_dev: pci_dev_maybe.unwrap() as u64,
-                                pci_func: pci_func_maybe.unwrap() as u64,
+                                pci_device,
                                 handle: handle as u64,
                                 vector: vector as u64,
                             },

--- a/tool/microkit/src/sdf.rs
+++ b/tool/microkit/src/sdf.rs
@@ -343,7 +343,7 @@ pub struct VirtualMachine {
     pub vcpus: Vec<VirtualCpu>,
     pub name: String,
     pub maps: Vec<SysMap>,
-    pub sched_params: SchedulingParams,
+    pub sched_params: Option<SchedulingParams>,
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -1246,33 +1246,50 @@ impl VirtualMachine {
         xml_sdf: &XmlSystemDescription,
         node: &roxmltree::Node,
     ) -> Result<VirtualMachine, String> {
-        check_attributes(xml_sdf, node, &["name", "budget", "period", "priority"])?;
-
-        let name = checked_lookup(xml_sdf, node, "name")?.to_string();
-        // If we do not have an explicit budget the period is equal to the default budget.
-        let budget = if let Some(xml_budget) = node.attribute("budget") {
-            sdf_parse_number(xml_budget, node)?
+        if config.arch == Arch::Aarch64 {
+            check_attributes(xml_sdf, node, &["name", "budget", "period", "priority"])?;
         } else {
-            BUDGET_DEFAULT
-        };
-        let period = if let Some(xml_period) = node.attribute("period") {
-            sdf_parse_number(xml_period, node)?
-        } else {
-            budget
-        };
-        if budget > period {
-            return Err(value_error(
-                xml_sdf,
-                node,
-                format!("budget ({budget}) must be less than, or equal to, period ({period})"),
-            ));
+            check_attributes(xml_sdf, node, &["name"])?;
         }
 
-        // Default to minimum priority
-        let priority = if let Some(xml_priority) = node.attribute("priority") {
-            sdf_parse_number(xml_priority, node)?
+        let name = checked_lookup(xml_sdf, node, "name")?.to_string();
+
+        let sched_params = if config.arch == Arch::Aarch64 {
+            // If we do not have an explicit budget the period is equal to the default budget.
+            let budget = if let Some(xml_budget) = node.attribute("budget") {
+                sdf_parse_number(xml_budget, node)?
+            } else {
+                BUDGET_DEFAULT
+            };
+            let period = if let Some(xml_period) = node.attribute("period") {
+                sdf_parse_number(xml_period, node)?
+            } else {
+                budget
+            };
+            if budget > period {
+                return Err(value_error(
+                    xml_sdf,
+                    node,
+                    format!("budget ({budget}) must be less than, or equal to, period ({period})"),
+                ));
+            }
+
+            // Default to minimum priority
+            let priority = if let Some(xml_priority) = node.attribute("priority") {
+                sdf_parse_number(xml_priority, node)?
+            } else {
+                0
+            };
+
+            Some(SchedulingParams {
+                // This downcast is safe as we have checked that this is less than
+                // the maximum PD priority, which fits in a u8.
+                priority: priority as u8,
+                budget,
+                period,
+            })
         } else {
-            0
+            None
         };
 
         let mut vcpus: Vec<VirtualCpu> = Vec::new();
@@ -1361,13 +1378,7 @@ impl VirtualMachine {
             vcpus,
             name,
             maps,
-            sched_params: SchedulingParams {
-                // This downcast is safe as we have checked that this is less than
-                // the maximum PD priority, which fits in a u8.
-                priority: priority as u8,
-                budget,
-                period,
-            },
+            sched_params,
         })
     }
 }

--- a/tool/microkit/src/sdf.rs
+++ b/tool/microkit/src/sdf.rs
@@ -113,6 +113,40 @@ pub struct SysMap {
     pub text_pos: Option<roxmltree::TextPos>,
 }
 
+trait Map {
+    fn mr_name(&self) -> &str;
+    fn addr(&self) -> u64;
+    fn text_pos(&self) -> Option<roxmltree::TextPos>;
+    fn element(&self) -> &'static str;
+    fn addr_name(&self) -> &'static str;
+    fn range_name(&self) -> &'static str;
+}
+
+impl Map for SysMap {
+    fn mr_name(&self) -> &str {
+        &self.mr
+    }
+
+    fn addr(&self) -> u64 {
+        self.vaddr
+    }
+
+    fn text_pos(&self) -> Option<roxmltree::TextPos> {
+        self.text_pos
+    }
+
+    fn element(&self) -> &'static str {
+        "map"
+    }
+
+    fn addr_name(&self) -> &'static str {
+        "vaddr"
+    }
+
+    fn range_name(&self) -> &'static str {
+        "virtual address range"
+    }
+}
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub enum SysMemoryRegionKind {
     User,
@@ -350,49 +384,6 @@ pub struct VirtualCpu {
     pub id: u64,
     pub setvar_id: Option<String>,
     pub cpu: Option<CpuCore>,
-}
-
-/// To avoid code duplication for handling protection domains
-/// and virtual machines, which have a lot in common.
-trait ExecutionContext {
-    fn name(&self) -> &String;
-    fn kind(&self) -> &'static str;
-}
-
-impl ExecutionContext for ProtectionDomain {
-    fn name(&self) -> &String {
-        &self.name
-    }
-
-    fn kind(&self) -> &'static str {
-        "protection domain"
-    }
-}
-
-impl ExecutionContext for VirtualMachine {
-    fn name(&self) -> &String {
-        &self.name
-    }
-
-    fn kind(&self) -> &'static str {
-        "virtual machine"
-    }
-}
-
-impl SysMapPerms {
-    fn from_str(s: &str) -> Result<u8, ()> {
-        let mut perms = 0;
-        for c in s.chars() {
-            match c {
-                'r' => perms |= SysMapPerms::Read as u8,
-                'w' => perms |= SysMapPerms::Write as u8,
-                'x' => perms |= SysMapPerms::Execute as u8,
-                _ => return Err(()),
-            }
-        }
-
-        Ok(perms)
-    }
 }
 
 impl SysMap {
@@ -1779,55 +1770,93 @@ pub struct SystemDescription {
     pub channels: Vec<Channel>,
 }
 
-fn check_maps(
+fn location_suffix_format(
+    xml_sdf: &XmlSystemDescription,
+    text_pos: Option<roxmltree::TextPos>,
+) -> String {
+    text_pos
+        .map(|pos| format!("@ {}", loc_string(xml_sdf, pos)))
+        .unwrap_or_default()
+}
+
+// max_end is the first invalid virtual address
+fn check_maps<'a, M, I>(
     xml_sdf: &XmlSystemDescription,
     mrs: &[SysMemoryRegion],
-    e: &dyn ExecutionContext,
-    maps: &[SysMap],
-) -> Result<(), String> {
-    let mut checked_maps = Vec::with_capacity(maps.len());
+    maps: I,
+    address_space: &str,
+    max_end: u64,
+) -> Result<(), String>
+where
+    M: Map + 'a,
+    I: IntoIterator<Item = &'a M>,
+{
+    let mut checked_maps: Vec<(&str, u64, u64)> = Vec::new();
+
     for map in maps {
-        let maybe_mr = mrs.iter().find(|mr| mr.name == map.mr);
-        let pos = map.text_pos.unwrap();
-        match maybe_mr {
+        let element = map.element();
+        match mrs.iter().find(|mr| mr.name == map.mr_name()) {
             Some(mr) => {
-                if !map.vaddr.is_multiple_of(mr.page_size_bytes()) {
+                if !map.addr().is_multiple_of(mr.page_size_bytes()) {
                     return Err(format!(
-                        "Error: invalid vaddr alignment on 'map' @ {}",
-                        loc_string(xml_sdf, pos)
+                        "Error: invalid {} alignment on '{element}' {}",
+                        map.addr_name(),
+                        location_suffix_format(xml_sdf, map.text_pos())
                     ));
                 }
 
-                let map_start = map.vaddr;
-                let map_end = map.vaddr + mr.size;
-                for (name, start, end) in &checked_maps {
+                let map_start = map.addr();
+                let Some(map_end) = map_start.checked_add(mr.size) else {
+                    return Err(format!(
+                        "Error: {element} for '{}' has address range that overflows {}",
+                        map.mr_name(),
+                        location_suffix_format(xml_sdf, map.text_pos())
+                    ));
+                };
+
+                if map_end > max_end {
+                    return Err(format!(
+                        "Error: {element} for '{}' has {} [{:#x}..{:#x}) which exceeds valid address space [{:#x}..{:#x}) {}",
+                        map.mr_name(),
+                        map.range_name(),
+                        map_start,
+                        map_end,
+                        0,
+                        max_end,
+                        location_suffix_format(xml_sdf, map.text_pos())
+                    ));
+                }
+
+                for (name, start, end) in checked_maps.iter() {
                     if !(map_start >= *end || map_end <= *start) {
-                        return Err(
-                            format!(
-                                "Error: map for '{}' has virtual address range [{:#x}..{:#x}) which overlaps with map for '{}' [{:#x}..{:#x}) in {} '{}' @ {}",
-                                map.mr,
-                                map_start,
-                                map_end,
-                                name,
-                                start,
-                                end,
-                                e.kind(),
-                                e.name(),
-                                loc_string(xml_sdf, map.text_pos.unwrap())
-                            )
-                        );
+                        return Err(format!(
+                            "Error: map for '{}' has {} [{:#x}..{:#x}) which overlaps with map for '{}' [{:#x}..{:#x}) in {} {}",
+                            map.mr_name(),
+                            map.range_name(),
+                            map_start,
+                            map_end,
+                            name,
+                            start,
+                            end,
+                            address_space,
+                            location_suffix_format(xml_sdf, map.text_pos())
+                        ));
                     }
                 }
-                checked_maps.push((&map.mr, map_start, map_end));
+                checked_maps.push((map.mr_name(), map_start, map_end));
             }
             None => {
                 return Err(format!(
-                    "Error: invalid memory region name '{}' on 'map' @ {}",
-                    map.mr,
-                    loc_string(xml_sdf, pos)
-                ))
+                    "Error: invalid memory region name '{}' on '{element}' {}",
+                    map.mr_name(),
+                    location_suffix_format(xml_sdf, map.text_pos())
+                ));
             }
-        };
+        }
+    }
+
+    Ok(())
+}
     }
 
     Ok(())
@@ -2322,9 +2351,21 @@ pub fn parse(
 
     // Ensure that all maps are correct
     for pd in &pds {
-        check_maps(&xml_sdf, &mrs, pd, &pd.maps)?;
+        check_maps(
+            &xml_sdf,
+            &mrs,
+            pd.maps.iter(),
+            &format!("protection domain '{}'", pd.name),
+            config.pd_map_max_vaddr(pd.stack_size),
+        )?;
         if let Some(vm) = &pd.virtual_machine {
-            check_maps(&xml_sdf, &mrs, vm, &vm.maps)?;
+            check_maps(
+                &xml_sdf,
+                &mrs,
+                vm.maps.iter(),
+                &format!("virtual machine '{}'", vm.name),
+                config.vm_map_max_vaddr(),
+            )?;
         }
     }
 

--- a/tool/microkit/src/sdf.rs
+++ b/tool/microkit/src/sdf.rs
@@ -266,13 +266,18 @@ impl Display for CpuCore {
 }
 
 #[derive(Debug, PartialEq, Eq)]
+pub struct SchedulingParams {
+    pub priority: u8,
+    pub budget: u64,
+    pub period: u64,
+}
+
+#[derive(Debug, PartialEq, Eq)]
 pub struct ProtectionDomain {
     /// Only populated for child protection domains
     pub id: Option<u64>,
     pub name: String,
-    pub priority: u8,
-    pub budget: u64,
-    pub period: u64,
+    pub sched_params: SchedulingParams,
     pub passive: bool,
     pub stack_size: u64,
     pub smc: bool,
@@ -338,9 +343,7 @@ pub struct VirtualMachine {
     pub vcpus: Vec<VirtualCpu>,
     pub name: String,
     pub maps: Vec<SysMap>,
-    pub priority: u8,
-    pub budget: u64,
-    pub period: u64,
+    pub sched_params: SchedulingParams,
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -496,6 +499,10 @@ impl ProtectionDomain {
         }
 
         ioports
+    }
+
+    pub fn priority(&self) -> u8 {
+        self.sched_params.priority
     }
 
     fn from_xml(
@@ -1204,11 +1211,13 @@ impl ProtectionDomain {
         Ok(ProtectionDomain {
             id,
             name,
-            // This downcast is safe as we have checked that this is less than
-            // the maximum PD priority, which fits in a u8.
-            priority: priority as u8,
-            budget,
-            period,
+            sched_params: SchedulingParams {
+                // This downcast is safe as we have checked that this is less than
+                // the maximum PD priority, which fits in a u8.
+                priority: priority as u8,
+                budget,
+                period,
+            },
             passive,
             stack_size,
             smc,
@@ -1352,11 +1361,13 @@ impl VirtualMachine {
             vcpus,
             name,
             maps,
-            // This downcast is safe as we have checked that this is less than
-            // the maximum VM priority, which fits in a u8.
-            priority: priority as u8,
-            budget,
-            period,
+            sched_params: SchedulingParams {
+                // This downcast is safe as we have checked that this is less than
+                // the maximum PD priority, which fits in a u8.
+                priority: priority as u8,
+                budget,
+                period,
+            },
         })
     }
 }
@@ -2211,17 +2222,23 @@ pub fn parse(
 
         let pd_a = &pds[ch.end_a.pd];
         let pd_b = &pds[ch.end_b.pd];
-        if ch.end_a.pp && pd_a.priority >= pd_b.priority {
+        if ch.end_a.pp && pd_a.priority() >= pd_b.priority() {
             return Err(format!(
                 "Error: PPCs must be to protection domains of strictly higher priorities; \
                         channel with PPC exists from pd {} (priority: {}) to pd {} (priority: {})",
-                pd_a.name, pd_a.priority, pd_b.name, pd_b.priority
+                pd_a.name,
+                pd_a.priority(),
+                pd_b.name,
+                pd_b.priority()
             ));
-        } else if ch.end_b.pp && pd_b.priority >= pd_a.priority {
+        } else if ch.end_b.pp && pd_b.priority() >= pd_a.priority() {
             return Err(format!(
                 "Error: PPCs must be to protection domains of strictly higher priorities; \
                         channel with PPC exists from pd {} (priority: {}) to pd {} (priority: {})",
-                pd_b.name, pd_b.priority, pd_a.name, pd_a.priority
+                pd_b.name,
+                pd_b.priority(),
+                pd_a.name,
+                pd_a.priority()
             ));
         }
 

--- a/tool/microkit/src/sdf.rs
+++ b/tool/microkit/src/sdf.rs
@@ -702,20 +702,12 @@ impl SysMap {
 
 impl SysIOMap {
     fn from_xml(
-        config: &Config,
+        _config: &Config,
         xml_sdf: &XmlSystemDescription,
         node: &roxmltree::Node,
         device: &str,
         identifier: IommuDeviceIdentifier,
     ) -> Result<SysIOMap, String> {
-        if config.arch != Arch::X86_64 {
-            return Err(value_error(
-                xml_sdf,
-                node,
-                "IOMMU is not yet supported on ARM and RISC-V by Microkit".to_string(),
-            ));
-        }
-
         let attrs = vec!["mr", "iovaddr", "perms"];
 
         check_attributes(xml_sdf, node, &attrs)?;
@@ -777,6 +769,14 @@ impl IOAddressSpace {
         device_names: &mut HashSet<String>,
         iommu_device_identifiers: &mut HashSet<IommuDeviceIdentifier>,
     ) -> Result<IOAddressSpace, String> {
+        let pos = xml_sdf.doc.text_pos_at(node.range().start);
+        if !config.iommu {
+            return Err(format!(
+                "Error: io address space requires seL4 to be built with IOMMU support: {}",
+                loc_string(xml_sdf, pos)
+            ));
+        }
+
         check_attributes(xml_sdf, node, &["name", "peripheral_id"])?;
         let device_name = checked_lookup(xml_sdf, node, "name")?;
         if !device_names.insert(device_name.to_string()) {

--- a/tool/microkit/src/sdf.rs
+++ b/tool/microkit/src/sdf.rs
@@ -62,6 +62,12 @@ const PD_MAX_STACK_SIZE: u64 = 1024 * 1024 * 16;
 /// `src/arch/x86/object/interrupt.c`
 const X86_IRQ_VECTOR_MAX: i64 = 107;
 
+// In reality the kernel dynamically determines this value. The tool assumes
+// at least 512GiB of IO virtual address space. This handles all values reported
+// to us by the kernel at runtime except for the 1GiB or no-iommu cases.
+// This is currently applied to any iommu mapping independent of the architecture.
+const IOMAP_MAX_VADDR: u64 = (1 << 39) - 1;
+
 /// The purpose of this function is to parse an integer that could
 /// either be in decimal or hex format, unlike the normal parsing
 /// functionality that the Rust standard library provides.
@@ -190,11 +196,76 @@ impl FromStr for PciDevice {
         })
     }
 }
+
+// This can be extended in future to support devices on an SMMU enabled Arm device
+// or IOMMU enabled RISC-V device.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum IommuDeviceIdentifier {
+    X86Pci(PciDevice),
+}
+
+#[derive(Clone, PartialEq, Eq)]
+pub enum IommuDeviceIdentifierParseError {
+    UnsupportedArch(Arch),
+    Pci(PciDeviceParseError),
+}
+
+impl IommuDeviceIdentifier {
+    fn from_str_for_arch(
+        config: &Config,
+        s: &str,
+    ) -> Result<Self, IommuDeviceIdentifierParseError> {
+        match config.arch {
+            Arch::X86_64 => PciDevice::from_str(s)
+                .map(IommuDeviceIdentifier::X86Pci)
+                .map_err(IommuDeviceIdentifierParseError::Pci),
+            Arch::Aarch64 | Arch::Riscv64 => Err(IommuDeviceIdentifierParseError::UnsupportedArch(
+                config.arch,
+            )),
+        }
+    }
+}
+
+impl fmt::Display for IommuDeviceIdentifier {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            IommuDeviceIdentifier::X86Pci(pci_device) => write!(f, "PCI device {pci_device}"),
+        }
+    }
+}
+
+impl fmt::Display for IommuDeviceIdentifierParseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            IommuDeviceIdentifierParseError::UnsupportedArch(arch) => {
+                write!(f, "IOMMU device identifiers are not supported on {arch}")
+            }
+            IommuDeviceIdentifierParseError::Pci(err) => write!(f, "{err}"),
+        }
+    }
+}
+
 #[repr(u8)]
 pub enum SysMapPerms {
     Read = 1,
     Write = 2,
     Execute = 4,
+}
+
+impl SysMapPerms {
+    fn from_str(s: &str) -> Result<u8, ()> {
+        let mut perms = 0;
+        for c in s.chars() {
+            match c {
+                'r' => perms |= SysMapPerms::Read as u8,
+                'w' => perms |= SysMapPerms::Write as u8,
+                'x' => perms |= SysMapPerms::Execute as u8,
+                _ => return Err(()),
+            }
+        }
+
+        Ok(perms)
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -205,6 +276,53 @@ pub struct SysMap {
     pub cached: bool,
     /// Location in the parsed SDF file. Because this struct is
     /// used in a non-XML context, we make the position optional.
+    pub text_pos: Option<roxmltree::TextPos>,
+}
+
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub enum SysIOMapPerms {
+    Read,
+    Write,
+    ReadWrite,
+}
+
+impl SysIOMapPerms {
+    fn from_str(s: &str) -> Result<Self, ()> {
+        let mut read = false;
+        let mut write = false;
+
+        for c in s.chars() {
+            match c {
+                'r' => read = true,
+                'w' => write = true,
+                _ => return Err(()),
+            }
+        }
+
+        match (read, write) {
+            (true, true) => Ok(SysIOMapPerms::ReadWrite),
+            (true, false) => Ok(SysIOMapPerms::Read),
+            (false, true) => Ok(SysIOMapPerms::Write),
+            (false, false) => Err(()),
+        }
+    }
+
+    pub fn read(self) -> bool {
+        matches!(self, SysIOMapPerms::Read | SysIOMapPerms::ReadWrite)
+    }
+
+    pub fn write(self) -> bool {
+        matches!(self, SysIOMapPerms::Write | SysIOMapPerms::ReadWrite)
+    }
+}
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct SysIOMap {
+    pub device: String,
+    pub mr: String,
+    pub identifier: IommuDeviceIdentifier,
+    pub iovaddr: u64,
+    pub perms: SysIOMapPerms,
     pub text_pos: Option<roxmltree::TextPos>,
 }
 
@@ -240,6 +358,32 @@ impl Map for SysMap {
 
     fn range_name(&self) -> &'static str {
         "virtual address range"
+    }
+}
+
+impl Map for SysIOMap {
+    fn mr_name(&self) -> &str {
+        &self.mr
+    }
+
+    fn addr(&self) -> u64 {
+        self.iovaddr
+    }
+
+    fn text_pos(&self) -> Option<roxmltree::TextPos> {
+        self.text_pos
+    }
+
+    fn element(&self) -> &'static str {
+        "iomap"
+    }
+
+    fn addr_name(&self) -> &'static str {
+        "iovaddr"
+    }
+
+    fn range_name(&self) -> &'static str {
+        "io address range"
     }
 }
 #[derive(Debug, PartialEq, Eq, Clone)]
@@ -553,6 +697,137 @@ impl SysMap {
             cached,
             text_pos: Some(xml_sdf.doc.text_pos_at(node.range().start)),
         })
+    }
+}
+
+impl SysIOMap {
+    fn from_xml(
+        config: &Config,
+        xml_sdf: &XmlSystemDescription,
+        node: &roxmltree::Node,
+        device: &str,
+        identifier: IommuDeviceIdentifier,
+    ) -> Result<SysIOMap, String> {
+        if config.arch != Arch::X86_64 {
+            return Err(value_error(
+                xml_sdf,
+                node,
+                "IOMMU is not yet supported on ARM and RISC-V by Microkit".to_string(),
+            ));
+        }
+
+        let attrs = vec!["mr", "iovaddr", "perms"];
+
+        check_attributes(xml_sdf, node, &attrs)?;
+
+        let mr = checked_lookup(xml_sdf, node, "mr")?.to_string();
+        let iovaddr = sdf_parse_number(checked_lookup(xml_sdf, node, "iovaddr")?, node)?;
+
+        if iovaddr > IOMAP_MAX_VADDR {
+            return Err(value_error(
+                xml_sdf,
+                node,
+                format!(
+                    "iovaddr ({iovaddr:#x}) must be less than {:#x}",
+                    IOMAP_MAX_VADDR + 1
+                ),
+            ));
+        }
+
+        let perms = if let Some(xml_perms) = node.attribute("perms") {
+            match SysIOMapPerms::from_str(xml_perms) {
+                Ok(parsed_perms) => parsed_perms,
+                Err(()) => {
+                    return Err(value_error(
+                        xml_sdf,
+                        node,
+                        "perms for io mapped memory must only be a combination of 'r' and 'w'"
+                            .to_string(),
+                    ))
+                }
+            }
+        } else {
+            // Default to read-write
+            SysIOMapPerms::ReadWrite
+        };
+
+        Ok(SysIOMap {
+            device: device.to_string(),
+            mr,
+            identifier,
+            iovaddr,
+            perms,
+            text_pos: Some(xml_sdf.doc.text_pos_at(node.range().start)),
+        })
+    }
+}
+
+// This is implemented in such a way that each device will have its own address space.
+// If devices need to share physical memory, this can be done by mapping the same memory_region
+// into each address space.
+struct IOAddressSpace {
+    iomaps: Vec<SysIOMap>,
+}
+
+impl IOAddressSpace {
+    fn from_xml(
+        config: &Config,
+        xml_sdf: &XmlSystemDescription,
+        node: &roxmltree::Node,
+        device_names: &mut HashSet<String>,
+        iommu_device_identifiers: &mut HashSet<IommuDeviceIdentifier>,
+    ) -> Result<IOAddressSpace, String> {
+        check_attributes(xml_sdf, node, &["name", "peripheral_id"])?;
+        let device_name = checked_lookup(xml_sdf, node, "name")?;
+        if !device_names.insert(device_name.to_string()) {
+            return Err(value_error(
+                xml_sdf,
+                node,
+                format!("duplicate device name '{device_name}'"),
+            ));
+        }
+
+        // In the SDF we use peripheral_id as an architecture agnostic way to describe
+        // how a device is identified in a system. For example on x86 the IOMMU identifies
+        // devices by the PCI tuple (bus,dev,fn)
+        let identifier_str = checked_lookup(xml_sdf, node, "peripheral_id")?;
+        let identifier =
+            IommuDeviceIdentifier::from_str_for_arch(config, identifier_str).map_err(|err| {
+                value_error(
+                    xml_sdf,
+                    node,
+                    format!("failed to parse device peripheral_id '{identifier_str}': {err}"),
+                )
+            })?;
+        if !iommu_device_identifiers.insert(identifier) {
+            return Err(value_error(
+                xml_sdf,
+                node,
+                format!("duplicate device peripheral_id '{identifier}'"),
+            ));
+        }
+
+        let mut iomaps = Vec::new();
+
+        for child in node.children().filter(|node| node.is_element()) {
+            match child.tag_name().name() {
+                "iomap" => {
+                    let iomap =
+                        SysIOMap::from_xml(config, xml_sdf, &child, device_name, identifier)?;
+                    iomaps.push(iomap);
+                }
+                _ => {
+                    let pos = xml_sdf.doc.text_pos_at(child.range().start);
+                    return Err(format!(
+                        "Error: invalid XML element '{}': {}",
+                        child.tag_name().name(),
+                        loc_string(xml_sdf, pos)
+                    ));
+                }
+            }
+        }
+
+        Ok(IOAddressSpace { iomaps })
     }
 }
 
@@ -1772,6 +2047,7 @@ struct XmlSystemDescription<'a> {
 pub struct SystemDescription {
     pub protection_domains: Vec<ProtectionDomain>,
     pub memory_regions: Vec<SysMemoryRegion>,
+    pub iomaps: Vec<SysIOMap>,
     pub channels: Vec<Channel>,
 }
 
@@ -1862,6 +2138,21 @@ where
 
     Ok(())
 }
+
+fn check_io_maps(
+    xml_sdf: &XmlSystemDescription,
+    mrs: &[SysMemoryRegion],
+    iomaps: &[SysIOMap],
+) -> Result<(), String> {
+    let mut by_device: HashMap<IommuDeviceIdentifier, Vec<&SysIOMap>> = HashMap::new();
+
+    for iomap in iomaps {
+        by_device.entry(iomap.identifier).or_default().push(iomap);
+    }
+
+    for (identifier, maps) in by_device {
+        let address_space = identifier.to_string();
+        check_maps(xml_sdf, mrs, maps, &address_space, IOMAP_MAX_VADDR + 1)?;
     }
 
     Ok(())
@@ -2043,6 +2334,9 @@ pub fn parse(
 
     let mut root_pds = vec![];
     let mut mrs = vec![];
+    let mut iomaps = vec![];
+    let mut device_names = HashSet::new();
+    let mut iommu_device_identifiers = HashSet::new();
     let mut channels = vec![];
     let system = doc
         .root()
@@ -2075,6 +2369,18 @@ pub fn parse(
                 &child,
                 search_paths,
             )?),
+            "io_address_space" => {
+                iomaps.extend(
+                    IOAddressSpace::from_xml(
+                        config,
+                        &xml_sdf,
+                        &child,
+                        &mut device_names,
+                        &mut iommu_device_identifiers,
+                    )?
+                    .iomaps,
+                );
+            }
             "virtual_machine" => {
                 let pos = xml_sdf.doc.text_pos_at(child.range().start);
                 return Err(format!(
@@ -2196,7 +2502,7 @@ pub fn parse(
             // expose this footgun to users.
             return Err(format!(
                     "Error: It is not possible for PD '{}' with a bound vCPU to have children on x86_64: {}",
-                    pd.name(),
+                    pd.name,
                     loc_string(&xml_sdf, pd.text_pos.unwrap())));
         }
     }
@@ -2373,6 +2679,8 @@ pub fn parse(
             )?;
         }
     }
+
+    check_io_maps(&xml_sdf, &mrs, &iomaps)?;
 
     // Ensure that there are no overlapping extra cap maps in the user caps region
     // and we are not mapping in the same cap from the same source more than once
@@ -2551,6 +2859,7 @@ pub fn parse(
     Ok(SystemDescription {
         protection_domains: pds,
         memory_regions: mrs,
+        iomaps,
         channels,
     })
 }

--- a/tool/microkit/src/sdf.rs
+++ b/tool/microkit/src/sdf.rs
@@ -310,7 +310,6 @@ pub enum CapMapType {
     Tcb,
     Sc,
     VSpace,
-    CSpace,
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -1437,7 +1436,6 @@ impl CSpace {
                 "cap_tcb" => CapMap::from_xml(CapMapType::Tcb, xml_sdf, &child)?,
                 "cap_sc" => CapMap::from_xml(CapMapType::Sc, xml_sdf, &child)?,
                 "cap_vspace" => CapMap::from_xml(CapMapType::VSpace, xml_sdf, &child)?,
-                "cap_cspace" => CapMap::from_xml(CapMapType::CSpace, xml_sdf, &child)?,
                 child_name => {
                     let location = loc_string(xml_sdf, xml_sdf.doc.text_pos_at(child.range().start));
                     if let Some(type_name) = child_name.strip_prefix("cap_") {

--- a/tool/microkit/src/sel4.rs
+++ b/tool/microkit/src/sel4.rs
@@ -303,6 +303,7 @@ pub struct Config {
     pub cap_address_bits: u64,
     pub fan_out_limit: u64,
     pub max_num_bootinfo_untypeds: u64,
+    pub iommu: bool,
     pub hypervisor: bool,
     pub benchmark: bool,
     pub num_cores: u8,

--- a/tool/microkit/src/viper.rs
+++ b/tool/microkit/src/viper.rs
@@ -207,8 +207,8 @@ pub fn get_sdf_view(system: &SystemDescription, current_pd: usize) -> Option<Sdf
 
         view.channel_ends.push(local.id);
 
-        let local_prio = current.priority;
-        let remote_prio = system.protection_domains[remote.pd].priority;
+        let local_prio = current.priority();
+        let remote_prio = system.protection_domains[remote.pd].priority();
 
         if local.pp && local_prio < remote_prio {
             view.ppcall_targets.push(local.id);

--- a/tool/microkit/tests/sdf/iommu_address_overflow.system
+++ b/tool/microkit/tests/sdf/iommu_address_overflow.system
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright 2026, UNSW.
+
+ SPDX-License-Identifier: BSD-2-Clause
+-->
+<system>
+    <memory_region name="region" size="0xffff_ffff_ffff_f000" />
+    <io_address_space name="test_device" peripheral_id="0:3.0">
+        <iomap mr="region" iovaddr="0x1000" />
+    </io_address_space>
+    <protection_domain name="test">
+        <program_image path="test" />
+    </protection_domain>
+</system>

--- a/tool/microkit/tests/sdf/iommu_address_overflow.system
+++ b/tool/microkit/tests/sdf/iommu_address_overflow.system
@@ -6,7 +6,7 @@
 -->
 <system>
     <memory_region name="region" size="0xffff_ffff_ffff_f000" />
-    <io_address_space name="test_device" peripheral_id="0:3.0">
+    <io_address_space name="test_device" peripheral_id="0:3.0" domain_id="1">
         <iomap mr="region" iovaddr="0x1000" />
     </io_address_space>
     <protection_domain name="test">

--- a/tool/microkit/tests/sdf/iommu_duplicate_device.system
+++ b/tool/microkit/tests/sdf/iommu_duplicate_device.system
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright 2026, UNSW.
+
+ SPDX-License-Identifier: BSD-2-Clause
+-->
+<system>
+    <memory_region name="region" size="0x1000" />
+    <io_address_space name="test_device" peripheral_id="0:3.0">
+        <iomap mr="region" iovaddr="0x0" />
+    </io_address_space>
+    <io_address_space name="test_device" peripheral_id="0:4.0">
+        <iomap mr="region" iovaddr="0x1000" />
+    </io_address_space>
+    <protection_domain name="test">
+        <program_image path="test" />
+    </protection_domain>
+</system>

--- a/tool/microkit/tests/sdf/iommu_duplicate_device.system
+++ b/tool/microkit/tests/sdf/iommu_duplicate_device.system
@@ -6,10 +6,10 @@
 -->
 <system>
     <memory_region name="region" size="0x1000" />
-    <io_address_space name="test_device" peripheral_id="0:3.0">
+    <io_address_space name="test_device" peripheral_id="0:3.0" domain_id="1">
         <iomap mr="region" iovaddr="0x0" />
     </io_address_space>
-    <io_address_space name="test_device" peripheral_id="0:4.0">
+    <io_address_space name="test_device" peripheral_id="0:4.0" domain_id="2">
         <iomap mr="region" iovaddr="0x1000" />
     </io_address_space>
     <protection_domain name="test">

--- a/tool/microkit/tests/sdf/iommu_duplicate_device_identifier.system
+++ b/tool/microkit/tests/sdf/iommu_duplicate_device_identifier.system
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright 2026, UNSW.
+
+ SPDX-License-Identifier: BSD-2-Clause
+-->
+<system>
+    <memory_region name="region" size="0x1000" />
+    <io_address_space name="device_a" peripheral_id="0:3.0">
+        <iomap mr="region" iovaddr="0x0" />
+    </io_address_space>
+    <io_address_space name="device_b" peripheral_id="0:3.0">
+        <iomap mr="region" iovaddr="0x1000" />
+    </io_address_space>
+    <protection_domain name="test">
+        <program_image path="test" />
+    </protection_domain>
+</system>

--- a/tool/microkit/tests/sdf/iommu_duplicate_device_identifier.system
+++ b/tool/microkit/tests/sdf/iommu_duplicate_device_identifier.system
@@ -6,10 +6,10 @@
 -->
 <system>
     <memory_region name="region" size="0x1000" />
-    <io_address_space name="device_a" peripheral_id="0:3.0">
+    <io_address_space name="device_a" peripheral_id="0:3.0" domain_id="1">
         <iomap mr="region" iovaddr="0x0" />
     </io_address_space>
-    <io_address_space name="device_b" peripheral_id="0:3.0">
+    <io_address_space name="device_b" peripheral_id="0:3.0" domain_id="2">
         <iomap mr="region" iovaddr="0x1000" />
     </io_address_space>
     <protection_domain name="test">

--- a/tool/microkit/tests/sdf/iommu_duplicate_domain_identifier.system
+++ b/tool/microkit/tests/sdf/iommu_duplicate_domain_identifier.system
@@ -6,8 +6,11 @@
 -->
 <system>
     <memory_region name="region" size="0x1000" />
-    <io_address_space name="test_device" peripheral_id="0:3.0"  domain_id="1">
-        <iomap mr="region" iovaddr="0x0" perms="rw" />
+    <io_address_space name="device_a" peripheral_id="0:3.0" domain_id="1">
+        <iomap mr="region" iovaddr="0x0" />
+    </io_address_space>
+    <io_address_space name="device_b" peripheral_id="0:3.0" domain_id="1">
+        <iomap mr="region" iovaddr="0x1000" />
     </io_address_space>
     <protection_domain name="test">
         <program_image path="test" />

--- a/tool/microkit/tests/sdf/iommu_missing_from_config.system
+++ b/tool/microkit/tests/sdf/iommu_missing_from_config.system
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright 2026, UNSW.
+
+ SPDX-License-Identifier: BSD-2-Clause
+-->
+<system>
+    <memory_region name="region" size="0x1000" />
+    <io_address_space name="test_device" peripheral_id="0:3.0">
+        <iomap mr="region" iovaddr="0x80_0000_0000" />
+    </io_address_space>
+    <protection_domain name="test">
+        <program_image path="test" />
+
+        <map mr="region" vaddr="0x5_000_000" />
+
+    </protection_domain>
+</system>

--- a/tool/microkit/tests/sdf/iommu_missing_from_config.system
+++ b/tool/microkit/tests/sdf/iommu_missing_from_config.system
@@ -6,7 +6,7 @@
 -->
 <system>
     <memory_region name="region" size="0x1000" />
-    <io_address_space name="test_device" peripheral_id="0:3.0">
+    <io_address_space name="test_device" peripheral_id="0:3.0" domain_id="1">
         <iomap mr="region" iovaddr="0x80_0000_0000" />
     </io_address_space>
     <protection_domain name="test">

--- a/tool/microkit/tests/sdf/iommu_out_of_bound.system
+++ b/tool/microkit/tests/sdf/iommu_out_of_bound.system
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright 2026, UNSW.
+
+ SPDX-License-Identifier: BSD-2-Clause
+-->
+<system>
+    <memory_region name="region" size="0x1000" />
+    <io_address_space name="test_device" peripheral_id="0:3.0">
+        <iomap mr="region" iovaddr="0x80_0000_0000" />
+    </io_address_space>
+    <protection_domain name="test">
+        <program_image path="test" />
+
+        <map mr="region" vaddr="0x5_000_000" />
+
+    </protection_domain>
+</system>

--- a/tool/microkit/tests/sdf/iommu_out_of_bound.system
+++ b/tool/microkit/tests/sdf/iommu_out_of_bound.system
@@ -6,7 +6,7 @@
 -->
 <system>
     <memory_region name="region" size="0x1000" />
-    <io_address_space name="test_device" peripheral_id="0:3.0">
+    <io_address_space name="test_device" peripheral_id="0:3.0" domain_id="1">
         <iomap mr="region" iovaddr="0x80_0000_0000" />
     </io_address_space>
     <protection_domain name="test">

--- a/tool/microkit/tests/sdf/iommu_overlap_different_devices.system
+++ b/tool/microkit/tests/sdf/iommu_overlap_different_devices.system
@@ -7,10 +7,10 @@
 <system>
     <memory_region name="region_a" size="0x1000" />
     <memory_region name="region_b" size="0x1000" />
-    <io_address_space name="device_a" peripheral_id="0:3.0">
+    <io_address_space name="device_a" peripheral_id="0:3.0" domain_id="1">
         <iomap mr="region_a" iovaddr="0x0" />
     </io_address_space>
-    <io_address_space name="device_b" peripheral_id="0:4.0">
+    <io_address_space name="device_b" peripheral_id="0:4.0" domain_id="2">
         <iomap mr="region_b" iovaddr="0x0" />
     </io_address_space>
     <protection_domain name="test">

--- a/tool/microkit/tests/sdf/iommu_overlap_different_devices.system
+++ b/tool/microkit/tests/sdf/iommu_overlap_different_devices.system
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright 2026, UNSW.
+
+ SPDX-License-Identifier: BSD-2-Clause
+-->
+<system>
+    <memory_region name="region_a" size="0x1000" />
+    <memory_region name="region_b" size="0x1000" />
+    <io_address_space name="device_a" peripheral_id="0:3.0">
+        <iomap mr="region_a" iovaddr="0x0" />
+    </io_address_space>
+    <io_address_space name="device_b" peripheral_id="0:4.0">
+        <iomap mr="region_b" iovaddr="0x0" />
+    </io_address_space>
+    <protection_domain name="test">
+        <program_image path="test" />
+    </protection_domain>
+</system>

--- a/tool/microkit/tests/sdf/iommu_overlap_mixed_page_sizes.system
+++ b/tool/microkit/tests/sdf/iommu_overlap_mixed_page_sizes.system
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright 2026, UNSW.
+
+ SPDX-License-Identifier: BSD-2-Clause
+-->
+<system>
+    <memory_region name="large_region" size="0x200000" page_size="0x200000" />
+    <memory_region name="small_region" size="0x1000" />
+    <io_address_space name="test_device" peripheral_id="0:3.0">
+        <iomap mr="large_region" iovaddr="0x0" />
+        <iomap mr="small_region" iovaddr="0x1000" />
+    </io_address_space>
+    <protection_domain name="test">
+        <program_image path="test" />
+    </protection_domain>
+</system>

--- a/tool/microkit/tests/sdf/iommu_overlap_mixed_page_sizes.system
+++ b/tool/microkit/tests/sdf/iommu_overlap_mixed_page_sizes.system
@@ -7,7 +7,7 @@
 <system>
     <memory_region name="large_region" size="0x200000" page_size="0x200000" />
     <memory_region name="small_region" size="0x1000" />
-    <io_address_space name="test_device" peripheral_id="0:3.0">
+    <io_address_space name="test_device" peripheral_id="0:3.0" domain_id="1">
         <iomap mr="large_region" iovaddr="0x0" />
         <iomap mr="small_region" iovaddr="0x1000" />
     </io_address_space>

--- a/tool/microkit/tests/sdf/iommu_overlap_same_device.system
+++ b/tool/microkit/tests/sdf/iommu_overlap_same_device.system
@@ -7,7 +7,7 @@
 <system>
     <memory_region name="region_a" size="0x1000" />
     <memory_region name="region_b" size="0x1000" />
-    <io_address_space name="test_device" peripheral_id="0:3.0">
+    <io_address_space name="test_device" peripheral_id="0:3.0" domain_id="1">
         <iomap mr="region_a" iovaddr="0x0" />
         <iomap mr="region_b" iovaddr="0x0" />
     </io_address_space>

--- a/tool/microkit/tests/sdf/iommu_overlap_same_device.system
+++ b/tool/microkit/tests/sdf/iommu_overlap_same_device.system
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright 2026, UNSW.
+
+ SPDX-License-Identifier: BSD-2-Clause
+-->
+<system>
+    <memory_region name="region_a" size="0x1000" />
+    <memory_region name="region_b" size="0x1000" />
+    <io_address_space name="test_device" peripheral_id="0:3.0">
+        <iomap mr="region_a" iovaddr="0x0" />
+        <iomap mr="region_b" iovaddr="0x0" />
+    </io_address_space>
+    <protection_domain name="test">
+        <program_image path="test" />
+    </protection_domain>
+</system>

--- a/tool/microkit/tests/sdf/iommu_pci_invalid.system
+++ b/tool/microkit/tests/sdf/iommu_pci_invalid.system
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright 2026, UNSW.
+
+ SPDX-License-Identifier: BSD-2-Clause
+-->
+<system>
+    <memory_region name="region" size="0x1000" />
+    <io_address_space name="test_device" peripheral_id="0:g.0">
+        <iomap mr="region" iovaddr="0x0" />
+    </io_address_space>
+    <protection_domain name="test">
+        <program_image path="test" />
+    </protection_domain>
+</system>

--- a/tool/microkit/tests/sdf/iommu_pci_invalid.system
+++ b/tool/microkit/tests/sdf/iommu_pci_invalid.system
@@ -6,7 +6,7 @@
 -->
 <system>
     <memory_region name="region" size="0x1000" />
-    <io_address_space name="test_device" peripheral_id="0:g.0">
+    <io_address_space name="test_device" peripheral_id="0:g.0" domain_id="1">
         <iomap mr="region" iovaddr="0x0" />
     </io_address_space>
     <protection_domain name="test">

--- a/tool/microkit/tests/sdf/iommu_pci_negative_bus.system
+++ b/tool/microkit/tests/sdf/iommu_pci_negative_bus.system
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright 2026, UNSW.
+
+ SPDX-License-Identifier: BSD-2-Clause
+-->
+<system>
+    <memory_region name="region" size="0x1000" />
+    <io_address_space name="test_device" peripheral_id="-1:0.0">
+        <iomap mr="region" iovaddr="0x0" />
+    </io_address_space>
+    <protection_domain name="test">
+        <program_image path="test" />
+    </protection_domain>
+</system>

--- a/tool/microkit/tests/sdf/iommu_pci_negative_bus.system
+++ b/tool/microkit/tests/sdf/iommu_pci_negative_bus.system
@@ -6,7 +6,7 @@
 -->
 <system>
     <memory_region name="region" size="0x1000" />
-    <io_address_space name="test_device" peripheral_id="-1:0.0">
+    <io_address_space name="test_device" peripheral_id="-1:0.0" domain_id="1">
         <iomap mr="region" iovaddr="0x0" />
     </io_address_space>
     <protection_domain name="test">

--- a/tool/microkit/tests/sdf/iommu_pci_negative_device.system
+++ b/tool/microkit/tests/sdf/iommu_pci_negative_device.system
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright 2026, UNSW.
+
+ SPDX-License-Identifier: BSD-2-Clause
+-->
+<system>
+    <memory_region name="region" size="0x1000" />
+    <io_address_space name="test_device" peripheral_id="0:-1.0">
+        <iomap mr="region" iovaddr="0x0" />
+    </io_address_space>
+    <protection_domain name="test">
+        <program_image path="test" />
+    </protection_domain>
+</system>

--- a/tool/microkit/tests/sdf/iommu_pci_negative_device.system
+++ b/tool/microkit/tests/sdf/iommu_pci_negative_device.system
@@ -6,7 +6,7 @@
 -->
 <system>
     <memory_region name="region" size="0x1000" />
-    <io_address_space name="test_device" peripheral_id="0:-1.0">
+    <io_address_space name="test_device" peripheral_id="0:-1.0" domain_id="1">
         <iomap mr="region" iovaddr="0x0" />
     </io_address_space>
     <protection_domain name="test">

--- a/tool/microkit/tests/sdf/iommu_pci_negative_function.system
+++ b/tool/microkit/tests/sdf/iommu_pci_negative_function.system
@@ -6,7 +6,7 @@
 -->
 <system>
     <memory_region name="region" size="0x1000" />
-    <io_address_space name="test_device" peripheral_id="0:0.-1">
+    <io_address_space name="test_device" peripheral_id="0:0.-1" domain_id="1">
         <iomap mr="region" iovaddr="0x0" />
     </io_address_space>
     <protection_domain name="test">

--- a/tool/microkit/tests/sdf/iommu_pci_negative_function.system
+++ b/tool/microkit/tests/sdf/iommu_pci_negative_function.system
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright 2026, UNSW.
+
+ SPDX-License-Identifier: BSD-2-Clause
+-->
+<system>
+    <memory_region name="region" size="0x1000" />
+    <io_address_space name="test_device" peripheral_id="0:0.-1">
+        <iomap mr="region" iovaddr="0x0" />
+    </io_address_space>
+    <protection_domain name="test">
+        <program_image path="test" />
+    </protection_domain>
+</system>

--- a/tool/microkit/tests/sdf/iommu_perms_execute_invalid.system
+++ b/tool/microkit/tests/sdf/iommu_perms_execute_invalid.system
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright 2026, UNSW.
+
+ SPDX-License-Identifier: BSD-2-Clause
+-->
+<system>
+    <memory_region name="region" size="0x1000" />
+    <io_address_space name="test_device" peripheral_id="0:3.0">
+        <iomap mr="region" iovaddr="0x0" perms="rx" />
+    </io_address_space>
+    <protection_domain name="test">
+        <program_image path="test" />
+    </protection_domain>
+</system>

--- a/tool/microkit/tests/sdf/iommu_perms_execute_invalid.system
+++ b/tool/microkit/tests/sdf/iommu_perms_execute_invalid.system
@@ -6,7 +6,7 @@
 -->
 <system>
     <memory_region name="region" size="0x1000" />
-    <io_address_space name="test_device" peripheral_id="0:3.0">
+    <io_address_space name="test_device" peripheral_id="0:3.0" domain_id="1">
         <iomap mr="region" iovaddr="0x0" perms="rx" />
     </io_address_space>
     <protection_domain name="test">

--- a/tool/microkit/tests/sdf/iommu_perms_read_write.system
+++ b/tool/microkit/tests/sdf/iommu_perms_read_write.system
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright 2026, UNSW.
+
+ SPDX-License-Identifier: BSD-2-Clause
+-->
+<system>
+    <memory_region name="region" size="0x1000" />
+    <io_address_space name="test_device" peripheral_id="0:3.0">
+        <iomap mr="region" iovaddr="0x0" perms="rw" />
+    </io_address_space>
+    <protection_domain name="test">
+        <program_image path="test" />
+    </protection_domain>
+</system>

--- a/tool/microkit/tests/sdf/iommu_perms_write_only.system
+++ b/tool/microkit/tests/sdf/iommu_perms_write_only.system
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright 2026, UNSW.
+
+ SPDX-License-Identifier: BSD-2-Clause
+-->
+<system>
+    <memory_region name="region" size="0x1000" />
+    <io_address_space name="test_device" peripheral_id="0:3.0">
+        <iomap mr="region" iovaddr="0x0" perms="w" />
+    </io_address_space>
+    <protection_domain name="test">
+        <program_image path="test" />
+    </protection_domain>
+</system>

--- a/tool/microkit/tests/sdf/iommu_perms_write_only.system
+++ b/tool/microkit/tests/sdf/iommu_perms_write_only.system
@@ -6,7 +6,7 @@
 -->
 <system>
     <memory_region name="region" size="0x1000" />
-    <io_address_space name="test_device" peripheral_id="0:3.0">
+    <io_address_space name="test_device" peripheral_id="0:3.0" domain_id="1">
         <iomap mr="region" iovaddr="0x0" perms="w" />
     </io_address_space>
     <protection_domain name="test">

--- a/tool/microkit/tests/sdf/iommu_range_out_of_bound.system
+++ b/tool/microkit/tests/sdf/iommu_range_out_of_bound.system
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright 2026, UNSW.
+
+ SPDX-License-Identifier: BSD-2-Clause
+-->
+<system>
+    <memory_region name="region" size="0xa00000" />
+    <io_address_space name="test_device" peripheral_id="0:3.0">
+        <iomap mr="region" iovaddr="0x7fff800000" />
+    </io_address_space>
+    <protection_domain name="test">
+        <program_image path="test" />
+    </protection_domain>
+</system>

--- a/tool/microkit/tests/sdf/iommu_range_out_of_bound.system
+++ b/tool/microkit/tests/sdf/iommu_range_out_of_bound.system
@@ -6,7 +6,7 @@
 -->
 <system>
     <memory_region name="region" size="0xa00000" />
-    <io_address_space name="test_device" peripheral_id="0:3.0">
+    <io_address_space name="test_device" peripheral_id="0:3.0" domain_id="1">
         <iomap mr="region" iovaddr="0x7fff800000" />
     </io_address_space>
     <protection_domain name="test">

--- a/tool/microkit/tests/sdf/iommu_same_mr_different_devices.system
+++ b/tool/microkit/tests/sdf/iommu_same_mr_different_devices.system
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright 2026, UNSW.
+
+ SPDX-License-Identifier: BSD-2-Clause
+-->
+<system>
+    <memory_region name="region" size="0x1000" />
+    <io_address_space name="device_a" peripheral_id="0:3.0">
+        <iomap mr="region" iovaddr="0x0" />
+    </io_address_space>
+    <io_address_space name="device_b" peripheral_id="0:4.0">
+        <iomap mr="region" iovaddr="0x0" />
+    </io_address_space>
+    <protection_domain name="test">
+        <program_image path="test" />
+    </protection_domain>
+</system>

--- a/tool/microkit/tests/sdf/iommu_same_mr_different_devices.system
+++ b/tool/microkit/tests/sdf/iommu_same_mr_different_devices.system
@@ -6,10 +6,10 @@
 -->
 <system>
     <memory_region name="region" size="0x1000" />
-    <io_address_space name="device_a" peripheral_id="0:3.0">
+    <io_address_space name="device_a" peripheral_id="0:3.0" domain_id="1">
         <iomap mr="region" iovaddr="0x0" />
     </io_address_space>
-    <io_address_space name="device_b" peripheral_id="0:4.0">
+    <io_address_space name="device_b" peripheral_id="0:4.0" domain_id="2">
         <iomap mr="region" iovaddr="0x0" />
     </io_address_space>
     <protection_domain name="test">

--- a/tool/microkit/tests/sdf/iommu_valid_perms_and_bound.system
+++ b/tool/microkit/tests/sdf/iommu_valid_perms_and_bound.system
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright 2026, UNSW.
+
+ SPDX-License-Identifier: BSD-2-Clause
+-->
+<system>
+    <memory_region name="region" size="0x1000" />
+    <io_address_space name="test_device" peripheral_id="0:3.0">
+        <iomap mr="region" iovaddr="0x7ffffff000" perms="r" />
+    </io_address_space>
+    <protection_domain name="test">
+        <program_image path="test" />
+    </protection_domain>
+</system>

--- a/tool/microkit/tests/sdf/iommu_valid_perms_and_bound.system
+++ b/tool/microkit/tests/sdf/iommu_valid_perms_and_bound.system
@@ -6,7 +6,7 @@
 -->
 <system>
     <memory_region name="region" size="0x1000" />
-    <io_address_space name="test_device" peripheral_id="0:3.0">
+    <io_address_space name="test_device" peripheral_id="0:3.0" domain_id="1">
         <iomap mr="region" iovaddr="0x7ffffff000" perms="r" />
     </io_address_space>
     <protection_domain name="test">

--- a/tool/microkit/tests/sdf/pd_cap_mappings_overlapping.system
+++ b/tool/microkit/tests/sdf/pd_cap_mappings_overlapping.system
@@ -21,9 +21,8 @@
             <cap_tcb    slot="1" pd="pd_a" />
             <cap_sc     slot="2" pd="pd_a" />
             <cap_vspace slot="3" pd="pd_a" />
-            <cap_cspace slot="4" pd="pd_a" />
             <!-- duplicate slot -->
-            <cap_cspace slot="4" pd="pd_a" />
+            <cap_vspace slot="3" pd="pd_a" />
         </cspace>
     </protection_domain>
 </system>

--- a/tool/microkit/tests/sdf/pd_overlapping_mixed_page_sizes.system
+++ b/tool/microkit/tests/sdf/pd_overlapping_mixed_page_sizes.system
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright 2026, UNSW.
+
+ SPDX-License-Identifier: BSD-2-Clause
+-->
+<system>
+    <memory_region name="large_region" size="0x200000" page_size="0x200000" />
+    <memory_region name="small_region" size="0x1000" />
+    <protection_domain name="test">
+        <program_image path="test" />
+        <map mr="large_region" vaddr="0x200000" />
+        <map mr="small_region" vaddr="0x201000" />
+    </protection_domain>
+</system>

--- a/tool/microkit/tests/sdf/sys_map_range_too_high.system
+++ b/tool/microkit/tests/sdf/sys_map_range_too_high.system
@@ -5,9 +5,9 @@
  SPDX-License-Identifier: BSD-2-Clause
 -->
 <system>
-    <memory_region name="foo" size="0x2_000" />
+    <memory_region name="foo" size="0x2_000_000_000_000" />
     <protection_domain name="test1" stack_size="0x1000">
         <program_image path="test" />
-        <map mr="foo" vaddr="0xffffffe000" />
+        <map mr="foo" vaddr="0xe_000_000_000" />
     </protection_domain>
 </system>

--- a/tool/microkit/tests/sdf/sys_map_range_too_high.system
+++ b/tool/microkit/tests/sdf/sys_map_range_too_high.system
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright 2026, UNSW.
+
+ SPDX-License-Identifier: BSD-2-Clause
+-->
+<system>
+    <memory_region name="foo" size="0x2_000" />
+    <protection_domain name="test1" stack_size="0x1000">
+        <program_image path="test" />
+        <map mr="foo" vaddr="0xffffffe000" />
+    </protection_domain>
+</system>

--- a/tool/microkit/tests/sdf/vm_valid.system
+++ b/tool/microkit/tests/sdf/vm_valid.system
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright 2026, UNSW
+    SPDX-License-Identifier: BSD-2-Clause
+-->
+<system>
+    <protection_domain name="hello" priority="254">
+        <program_image path="hello.elf" />
+        <virtual_machine name="guest">
+            <vcpu id="0" />
+        </virtual_machine>
+    </protection_domain>
+</system>

--- a/tool/microkit/tests/sdf/vm_with_priority.system
+++ b/tool/microkit/tests/sdf/vm_with_priority.system
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright 2026, UNSW
+    SPDX-License-Identifier: BSD-2-Clause
+-->
+<system>
+    <protection_domain name="hello" priority="254">
+        <program_image path="hello.elf" />
+        <virtual_machine name="guest" priority="1">
+            <vcpu id="0" />
+        </virtual_machine>
+    </protection_domain>
+</system>

--- a/tool/microkit/tests/test.rs
+++ b/tool/microkit/tests/test.rs
@@ -1317,7 +1317,7 @@ mod system {
         check_error(
             &DEFAULT_AARCH64_KERNEL_CONFIG,
             "sys_map_range_too_high.system",
-            "Error: map for 'foo' has virtual address range [0xffffffe000..0x10000000000) which exceeds valid address space [0x0..0xfffffff000) @",
+            "Error: map for 'foo' has virtual address range [0xe000000000..0x200e000000000) which exceeds valid address space",
         )
     }
 

--- a/tool/microkit/tests/test.rs
+++ b/tool/microkit/tests/test.rs
@@ -752,6 +752,30 @@ mod virtual_machine {
     use super::*;
 
     #[test]
+    fn test_vm_valid_aarch64() {
+        check_success(&DEFAULT_AARCH64_KERNEL_CONFIG, "vm_valid.system")
+    }
+
+    #[test]
+    fn test_vm_with_priority_aarch64() {
+        check_success(&DEFAULT_AARCH64_KERNEL_CONFIG, "vm_with_priority.system")
+    }
+
+    #[test]
+    fn test_vm_valid_x86_64() {
+        check_success(&DEFAULT_X86_64_KERNEL_CONFIG, "vm_valid.system")
+    }
+
+    #[test]
+    fn test_vm_with_priority_x86_64() {
+        check_error(
+            &DEFAULT_X86_64_KERNEL_CONFIG,
+            "vm_with_priority.system",
+            "Error: invalid attribute 'priority' on element 'virtual_machine'",
+        )
+    }
+
+    #[test]
     fn test_vm_not_child() {
         check_error(
             &DEFAULT_AARCH64_KERNEL_CONFIG,

--- a/tool/microkit/tests/test.rs
+++ b/tool/microkit/tests/test.rs
@@ -36,6 +36,7 @@ const DEFAULT_AARCH64_KERNEL_CONFIG: sel4::Config = sel4::Config {
     max_num_bootinfo_untypeds: 230,
     fan_out_limit: 256,
     hypervisor: true,
+    iommu: true,
     benchmark: false,
     num_cores: 1,
     fpu: true,
@@ -66,6 +67,7 @@ const DEFAULT_X86_64_KERNEL_CONFIG: sel4::Config = sel4::Config {
     max_num_bootinfo_untypeds: 230,
     fan_out_limit: 256,
     hypervisor: true,
+    iommu: true,
     benchmark: false,
     num_cores: 1,
     fpu: true,
@@ -758,6 +760,68 @@ mod protection_domain {
 #[cfg(test)]
 mod iommu {
     use super::*;
+
+    #[test]
+    fn test_iommu_missing_from_config() {
+        check_error(
+            &sel4::Config {
+                iommu: false,
+                ..DEFAULT_X86_64_KERNEL_CONFIG
+            },
+            "iommu_missing_from_config.system",
+            "Error: io address space requires seL4 to be built with IOMMU support: ",
+        );
+    }
+
+    #[test]
+    fn test_iommu_missing_from_aarch64_config() {
+        check_error(
+            &sel4::Config {
+                iommu: false,
+                ..DEFAULT_AARCH64_KERNEL_CONFIG
+            },
+            "iommu_missing_from_config.system",
+            "Error: io address space requires seL4 to be built with IOMMU support: ",
+        );
+    }
+
+    #[test]
+    fn test_iommu_missing_from_riscv64_config() {
+        check_error(
+            &sel4::Config {
+                arch: sel4::Arch::Riscv64,
+                iommu: false,
+                ..DEFAULT_AARCH64_KERNEL_CONFIG
+            },
+            "iommu_missing_from_config.system",
+            "Error: io address space requires seL4 to be built with IOMMU support: ",
+        );
+    }
+
+    #[test]
+    fn test_iommu_unsupported_on_aarch64() {
+        check_error(
+            &sel4::Config {
+                iommu: true,
+                ..DEFAULT_AARCH64_KERNEL_CONFIG
+            },
+            "iommu_missing_from_config.system",
+            "Error: failed to parse device peripheral_id '0:3.0': IOMMU device identifiers are not supported on AArch64 on element 'io_address_space':",
+        );
+    }
+
+    #[test]
+    fn test_iommu_unsupported_on_riscv64() {
+        check_error(
+            &sel4::Config {
+                arch: sel4::Arch::Riscv64,
+                iommu: true,
+                ..DEFAULT_AARCH64_KERNEL_CONFIG
+            },
+            "iommu_missing_from_config.system",
+            "Error: failed to parse device peripheral_id '0:3.0': IOMMU device identifiers are not supported on RISC-V (64-bit) on element 'io_address_space':",
+        );
+    }
 
     #[test]
     fn test_out_of_bound() {

--- a/tool/microkit/tests/test.rs
+++ b/tool/microkit/tests/test.rs
@@ -970,6 +970,15 @@ mod iommu {
             "Error: duplicate device peripheral_id 'PCI device 00:03.0' on element 'io_address_space':",
         )
     }
+
+    #[test]
+    fn test_duplicate_domain_identifier() {
+        check_error(
+            &DEFAULT_X86_64_KERNEL_CONFIG,
+            "iommu_duplicate_domain_identifier.system",
+            "Error: reusing a domain id is forbidden on element 'io_address_space'",
+        );
+    }
 }
 
 #[cfg(test)]

--- a/tool/microkit/tests/test.rs
+++ b/tool/microkit/tests/test.rs
@@ -1110,9 +1110,9 @@ mod system {
         check_error(
             &DEFAULT_AARCH64_KERNEL_CONFIG,
             "pd_cap_mappings_overlapping.system",
-            r#"Error: overlapping user caps in slot 4 of protection domain 'pd_b':
-  type CSpace from 'pd_a' at 'pd_cap_mappings_overlapping.system:24:13'
-  type CSpace from 'pd_a' at 'pd_cap_mappings_overlapping.system:26:13'"#,
+            r#"Error: overlapping user caps in slot 3 of protection domain 'pd_b':
+  type VSpace from 'pd_a' at 'pd_cap_mappings_overlapping.system:23:13'
+  type VSpace from 'pd_a' at 'pd_cap_mappings_overlapping.system:25:13'"#,
         )
     }
 

--- a/tool/microkit/tests/test.rs
+++ b/tool/microkit/tests/test.rs
@@ -641,7 +641,7 @@ mod protection_domain {
         check_error(
             &DEFAULT_X86_64_KERNEL_CONFIG,
             "irq_msi_pci_invalid.system",
-            "Error: failed to parse PCI address '0:0:0' on element 'irq'",
+            "Error: expected PCI address in bus:device.function form on element 'irq'",
         )
     }
 
@@ -713,6 +713,14 @@ mod protection_domain {
     }
 
     #[test]
+    fn test_overlapping_mixed_page_size_maps() {
+        check_error(&DEFAULT_AARCH64_KERNEL_CONFIG,
+            "pd_overlapping_mixed_page_sizes.system",
+            "Error: map for 'small_region' has virtual address range [0x201000..0x202000) which overlaps with map for 'large_region' [0x200000..0x400000) in protection domain 'test' @"
+        )
+    }
+
+    #[test]
     fn test_overlapping_x86_io_ports_1() {
         check_error(&DEFAULT_X86_64_KERNEL_CONFIG,
             "pd_overlapping_x86_io_ports_1.system",
@@ -743,6 +751,159 @@ mod protection_domain {
             &DEFAULT_AARCH64_KERNEL_CONFIG,
             "pd_invalid_cpu.system",
             "Error: cpu core must be less than 1, got 10 on element 'protection_domain':",
+        )
+    }
+}
+
+#[cfg(test)]
+mod iommu {
+    use super::*;
+
+    #[test]
+    fn test_out_of_bound() {
+        check_error(
+            &DEFAULT_X86_64_KERNEL_CONFIG,
+            "iommu_out_of_bound.system",
+            "Error: iovaddr (0x8000000000) must be less than 0x8000000000 on element 'iomap': iommu_out_of_bound.system:10:9",
+        )
+    }
+
+    #[test]
+    fn test_range_out_of_bound() {
+        check_error(
+            &DEFAULT_X86_64_KERNEL_CONFIG,
+            "iommu_range_out_of_bound.system",
+            "Error: iomap for 'region' has io address range [0x7fff800000..0x8000200000) which exceeds valid address space [0x0..0x8000000000) @",
+        )
+    }
+
+    #[test]
+    fn test_address_overflow() {
+        check_error(
+            &DEFAULT_X86_64_KERNEL_CONFIG,
+            "iommu_address_overflow.system",
+            "Error: iomap for 'region' has address range that overflows @",
+        )
+    }
+
+    #[test]
+    fn test_valid_perms_and_bound() {
+        check_success(
+            &DEFAULT_X86_64_KERNEL_CONFIG,
+            "iommu_valid_perms_and_bound.system",
+        )
+    }
+
+    #[test]
+    fn test_perms_read_write() {
+        check_success(
+            &DEFAULT_X86_64_KERNEL_CONFIG,
+            "iommu_perms_read_write.system",
+        )
+    }
+
+    #[test]
+    fn test_perms_write_only() {
+        check_success(
+            &DEFAULT_X86_64_KERNEL_CONFIG,
+            "iommu_perms_write_only.system",
+        )
+    }
+
+    #[test]
+    fn test_perms_execute_invalid() {
+        check_error(
+            &DEFAULT_X86_64_KERNEL_CONFIG,
+            "iommu_perms_execute_invalid.system",
+            "Error: perms for io mapped memory must only be a combination of 'r' and 'w' on element 'iomap':",
+        )
+    }
+
+    #[test]
+    fn test_overlap_different_devices() {
+        check_success(
+            &DEFAULT_X86_64_KERNEL_CONFIG,
+            "iommu_overlap_different_devices.system",
+        )
+    }
+
+    #[test]
+    fn test_overlap_same_device() {
+        check_error(
+            &DEFAULT_X86_64_KERNEL_CONFIG,
+            "iommu_overlap_same_device.system",
+            "Error: map for 'region_b' has io address range [0x0..0x1000) which overlaps with map for 'region_a' [0x0..0x1000) in PCI device 00:03.0 @ iommu_overlap_same_device.system:12:9",
+        )
+    }
+
+    #[test]
+    fn test_same_mr_different_devices() {
+        check_success(
+            &DEFAULT_X86_64_KERNEL_CONFIG,
+            "iommu_same_mr_different_devices.system",
+        )
+    }
+
+    #[test]
+    fn test_overlap_mixed_page_sizes() {
+        check_error(
+            &DEFAULT_X86_64_KERNEL_CONFIG,
+            "iommu_overlap_mixed_page_sizes.system",
+            "Error: map for 'small_region' has io address range [0x1000..0x2000) which overlaps with map for 'large_region' [0x0..0x200000) in PCI device 00:03.0 @",
+        )
+    }
+
+    #[test]
+    fn test_pci_invalid() {
+        check_error(
+            &DEFAULT_X86_64_KERNEL_CONFIG,
+            "iommu_pci_invalid.system",
+            "Error: failed to parse device peripheral_id '0:g.0': failed to parse PCI device on element 'io_address_space': iommu_pci_invalid.system:9:5",
+        )
+    }
+
+    #[test]
+    fn test_pci_negative_bus() {
+        check_error(
+            &DEFAULT_X86_64_KERNEL_CONFIG,
+            "iommu_pci_negative_bus.system",
+            "Error: failed to parse device peripheral_id '-1:0.0': PCI bus must be within [0..255] on element 'io_address_space':",
+        )
+    }
+
+    #[test]
+    fn test_pci_negative_device() {
+        check_error(
+            &DEFAULT_X86_64_KERNEL_CONFIG,
+            "iommu_pci_negative_device.system",
+            "Error: failed to parse device peripheral_id '0:-1.0': PCI device must be within [0..31] on element 'io_address_space':",
+        )
+    }
+
+    #[test]
+    fn test_pci_negative_function() {
+        check_error(
+            &DEFAULT_X86_64_KERNEL_CONFIG,
+            "iommu_pci_negative_function.system",
+            "Error: failed to parse device peripheral_id '0:0.-1': PCI function must be within [0..7] on element 'io_address_space':",
+        )
+    }
+
+    #[test]
+    fn test_duplicate_device() {
+        check_error(
+            &DEFAULT_X86_64_KERNEL_CONFIG,
+            "iommu_duplicate_device.system",
+            "Error: duplicate device name 'test_device' on element 'io_address_space':",
+        )
+    }
+
+    #[test]
+    fn test_duplicate_device_identifier() {
+        check_error(
+            &DEFAULT_X86_64_KERNEL_CONFIG,
+            "iommu_duplicate_device_identifier.system",
+            "Error: duplicate device peripheral_id 'PCI device 00:03.0' on element 'io_address_space':",
         )
     }
 }
@@ -1084,6 +1245,15 @@ mod system {
             &DEFAULT_AARCH64_KERNEL_CONFIG,
             "sys_map_too_high.system",
             "Error: vaddr (0x1000000000000000) must be less than 0xffffffc000 on element 'map'",
+        )
+    }
+
+    #[test]
+    fn test_map_range_too_high() {
+        check_error(
+            &DEFAULT_AARCH64_KERNEL_CONFIG,
+            "sys_map_range_too_high.system",
+            "Error: map for 'foo' has virtual address range [0xffffffe000..0x10000000000) which exceeds valid address space [0x0..0xfffffff000) @",
         )
     }
 


### PR DESCRIPTION
This PR makes a small change to the SDF work previously completed. 

It then refactors the memory.rs module in preparation for adding support for IO Address Spaces. The refactor primarily introduces an address space abstraction that can allow simpler handling of different address space variants.

It also removes the pre-existing duplicated constants that are already defined by seL4. This commit extracts those and includes them in the Config struct that the tool passes around.

This PR preserves the existing behaviour.