### PR TITLE
Microkit seL4Config: remove duplicate constant definitions

### DIFF
--- a/build_sdk.py
+++ b/build_sdk.py
@@ -726,32 +726,35 @@ def build_sel4(
 
     # Use the preprocessor to convert the seL4 object size constants to readable JSON
     # for the tool.
-    object_sizes_header = tool_dir / "object_sizes.h"
-    dest = sdk_dir / "board" / board.name / config.name / "object_sizes.json"
-    preprocessor = "clang" if (llvm) else f"{target_triple}-cpp"
-    preprocess_cmd = [
-        preprocessor,
-        "-E",
-        "-P",
-        f"-I{include_dir}",
-        object_sizes_header,
-    ]
-    r = subprocess.run(preprocess_cmd, capture_output=True)
-    if r.returncode != 0:
-        raise Exception(f"Failed creating object_sizes.json: cmd={preprocess_cmd}")
+    sel4_constants = ["object_sizes", "address_space_constants"]
+    for sel4_constant_type in sel4_constants:
+        header_src = tool_dir / f"{sel4_constant_type}.h"
+        json_dst = sdk_dir / "board" / board.name / config.name / f"{sel4_constant_type}.json"
+        preprocessor = "clang" if (llvm) else f"{target_triple}-cpp"
+        preprocess_cmd = [
+            preprocessor,
+            "-E",
+            "-P",
+            f"-I{include_dir}",
+            header_src,
+        ]
+        r = subprocess.run(preprocess_cmd, capture_output=True)
+        if r.returncode != 0:
+            raise Exception(f"Failed creating object_sizes.json: cmd={preprocess_cmd}")
+        sizes = []
+        for l in r.stdout.decode("utf-8").split("\n"):
+            # Preprocessor emits commented lines etc that we want to ignore
+            if ": " in l:
+                assert len(l.split(": ")) == 2
+                obj_name, size = l.split(": ")
+                if "-" in size:
+                    lhs, rhs = size.strip("( )").split("-", 1)
+                    size = str(int(lhs.strip(), 0) - int(rhs.strip(), 0))
+                sizes.append((obj_name, int(size, 0)))
 
-    preprocessor_out = r.stdout.decode("utf-8")
-    object_sizes = []
-    for l in preprocessor_out.split("\n"):
-        # Preprocessor emits commented lines etc that we want to ignore
-        if ": " in l:
-            assert len(l.split(": ")) == 2
-            obj_name, size = l.split(": ")
-            object_sizes.append((obj_name, int(size)))
-
-    with open(dest, "w") as out_file:
-        json.dump(dict(object_sizes), out_file)
-        dest.chmod(0o744)
+        with open(json_dst, "w") as out_file:
+            json.dump(dict(sizes), out_file)
+            json_dst.chmod(0o744)
 
 
 def build_elf_component(

--- a/tool/microkit/address_space_constants.h
+++ b/tool/microkit/address_space_constants.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2026, UNSW
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <sel4/arch/constants.h>
+#include <sel4/constants.h>
+#include <sel4/plat/api/constants.h>
+#include <sel4/sel4_arch/constants.h>
+
+page_table_index_bits: seL4_PageTableIndexBits
+
+#ifdef seL4_UserVSpaceTop
+vspace_user_top: seL4_UserVSpaceTop
+#endif
+
+#ifdef seL4_VSpaceIndexBits
+vspace_index_bits: seL4_VSpaceIndexBits
+#endif
+
+#ifdef seL4_IOPageTableIndexBits
+io_page_table_index_bits: seL4_IOPageTableIndexBits
+#endif

--- a/tool/microkit/src/capdl/memory.rs
+++ b/tool/microkit/src/capdl/memory.rs
@@ -8,7 +8,7 @@ use crate::{
         spec::capdl_obj_human_name, util::capdl_util_make_cte, CapDLNamedObject,
         CapDLSpecContainer, FrameFill,
     },
-    sel4::{Arch, Config, PageSize},
+    sel4::{Arch, Config, ObjectType, PageSize},
 };
 use sel4_capdl_initializer_types::{cap, object, Cap, Object, ObjectId};
 use std::ops::Range;
@@ -81,7 +81,7 @@ impl AddressSpace {
             spec_container,
             sel4_config,
             self.root(),
-            Self::get_root_level(sel4_config),
+            self.get_root_level(sel4_config),
             frame_cap,
             frame_size_bytes,
             addr,
@@ -114,40 +114,39 @@ impl AddressSpace {
         }
     }
 
+    fn get_leaf_bits(&self, sel4_config: &Config) -> u64 {
+        match self {
+            Self::VSpace { .. } => ObjectType::SmallPage.fixed_size_bits(sel4_config).unwrap(),
+        }
+    }
+
+    fn level_index_bits(&self, sel4_config: &Config, level: usize) -> u64 {
+        match self {
+            Self::VSpace { .. } => sel4_config.vspace_level_index_bits(level),
+        }
+    }
+
     fn get_level_index(&self, sel4_config: &Config, level: usize, vaddr: u64) -> usize {
         let levels = self.address_space_levels(sel4_config);
-
         assert!(level < levels);
 
-        let index_bits = |level: usize| -> u64 {
-            if matches!(self, AddressSpace::VSpace { .. })
-                && level == Self::get_root_level(sel4_config)
-                && sel4_config.arch == Arch::Aarch64
-                && sel4_config.aarch64_vspace_s2_start_l1()
-            {
-                // Special case for first level on AArch64 platforms with hyp and 40 bits PA.
-                // It have 10 bits index for VSpace.
-                // match up with seL4_VSpaceBits in seL4/libsel4/sel4_arch_include/aarch64/sel4/sel4_arch/constants.h
-                10
-            } else {
-                9
-            }
-        };
-
-        let page_bits = 12;
-        let bits_from_higher_lvls: u64 = ((level + 1)..levels).map(index_bits).sum();
+        let page_bits = self.get_leaf_bits(sel4_config);
+        let bits_from_higher_lvls: u64 = ((level + 1)..levels)
+            .map(|level| self.level_index_bits(sel4_config, level))
+            .sum();
         let shift = page_bits + bits_from_higher_lvls;
-        let width = index_bits(level);
+        let width = self.level_index_bits(sel4_config, level);
         let mask = (1u64 << width) - 1;
 
         ((vaddr >> shift) & mask) as usize
     }
 
     fn get_level_coverage(&self, sel4_config: &Config, level: usize, vaddr: u64) -> Range<u64> {
-        let levels = self.address_space_levels(sel4_config) as u64;
-
-        let page_bits = 12;
-        let bits_from_higher_lvls: u64 = (levels - (level as u64)) * 9;
+        let levels = self.address_space_levels(sel4_config);
+        let page_bits = self.get_leaf_bits(sel4_config);
+        let bits_from_higher_lvls: u64 = ((level + 1)..levels)
+            .map(|level| self.level_index_bits(sel4_config, level))
+            .sum();
 
         let coverage_bits = page_bits + bits_from_higher_lvls;
 
@@ -347,11 +346,9 @@ impl AddressSpace {
         }
     }
 
-    fn get_root_level(sel4_config: &Config) -> usize {
-        if sel4_config.arch == Arch::Aarch64 && sel4_config.aarch64_vspace_s2_start_l1() {
-            1
-        } else {
-            0
+    fn get_root_level(&self, sel4_config: &Config) -> usize {
+        match self {
+            AddressSpace::VSpace { .. } => sel4_config.vspace_root_level(),
         }
     }
 }
@@ -362,7 +359,7 @@ fn create_vspace_address_space(
     name: &str,
     x86_ept: bool,
 ) -> AddressSpace {
-    let root_level = AddressSpace::get_root_level(sel4_config);
+    let root_level = sel4_config.vspace_root_level();
 
     let root = spec_container.add_root_object(CapDLNamedObject {
         name: format!("{}_{}", get_pt_level_name(sel4_config, root_level), name).into(),

--- a/tool/microkit/src/main.rs
+++ b/tool/microkit/src/main.rs
@@ -21,8 +21,8 @@ use microkit_tool::report::write_report;
 use microkit_tool::sdf::{parse, SysMemoryRegion, SysMemoryRegionPaddr};
 use microkit_tool::sdk::Sdk;
 use microkit_tool::sel4::{
-    emulate_kernel_boot, emulate_kernel_boot_partial, Arch, Config, PlatformConfig,
-    RiscvVirtualMemory,
+    emulate_kernel_boot, emulate_kernel_boot_partial, AddressSpaceConstants, Arch, Config,
+    ObjectSizes, PlatformConfig, RiscvVirtualMemory,
 };
 use microkit_tool::symbols::patch_symbols;
 use microkit_tool::util::{
@@ -197,12 +197,22 @@ fn main() -> Result<(), String> {
         }
     };
 
-    let object_sizes = {
-        let object_sizes_path = current_config.config_dir.join("object_sizes.json");
-        bail_if_not_exists("kernel object sizes file", &object_sizes_path)?;
+    let object_sizes_path = current_config.config_dir.join("object_sizes.json");
+    bail_if_not_exists("kernel object sizes file", &object_sizes_path)?;
+    let object_sizes: ObjectSizes =
+        serde_json::from_str(&fs::read_to_string(object_sizes_path).unwrap())
+            .expect("Unable to parse {object_sizes_path}");
 
-        serde_json::from_str(&fs::read_to_string(object_sizes_path).unwrap()).unwrap()
-    };
+    let address_space_constants_path = current_config
+        .config_dir
+        .join("address_space_constants.json");
+    bail_if_not_exists(
+        "kernel address space constants file",
+        &address_space_constants_path,
+    )?;
+    let address_space_constants: AddressSpaceConstants =
+        serde_json::from_str(&fs::read_to_string(address_space_constants_path).unwrap())
+            .expect("Unable to parse {address_space_constants_path}");
 
     let hypervisor = match arch {
         Arch::Aarch64 => json_str_as_bool(&kernel_config_json, "ARM_HYPERVISOR_SUPPORT")?,
@@ -243,7 +253,7 @@ fn main() -> Result<(), String> {
     let kernel_config = Config {
         arch,
         word_size: json_str_as_u64(&kernel_config_json, "WORD_SIZE")?,
-        minimum_page_size: 4096,
+        minimum_page_size: 1 << object_sizes.small_page,
         paddr_user_device_top: json_str_as_u64(&kernel_config_json, "PADDR_USER_DEVICE_TOP")?,
         kernel_frame_size,
         init_cnode_bits: json_str_as_u64(&kernel_config_json, "ROOT_CNODE_SIZE_BITS")?,
@@ -270,7 +280,8 @@ fn main() -> Result<(), String> {
         invocations_labels,
         device_regions,
         normal_regions,
-        object_sizes,
+        object_sizes: Some(object_sizes),
+        address_space_constants,
     };
 
     if kernel_config.arch != Arch::X86_64 && !loader_elf_path.exists() {

--- a/tool/microkit/src/sel4.rs
+++ b/tool/microkit/src/sel4.rs
@@ -261,9 +261,23 @@ pub struct PlatformConfig {
     pub memory: Vec<PlatformConfigRegion>,
 }
 
+/// Deserialised from a generated 'address_space_constants.json' file in the SDK.
+#[derive(Debug, Deserialize)]
+pub struct AddressSpaceConstants {
+    pub page_table_index_bits: u64,
+    #[serde(default)]
+    /// Only included for aarch64 builds
+    pub vspace_index_bits: Option<u64>,
+    #[serde(default)]
+    // Only included for x86 VT-D builds
+    pub io_page_table_index_bits: Option<u64>,
+    /// seL4_UserVSpaceTop.
+    pub vspace_user_top: u64,
+}
+
 /// Deserialised from a generated 'object_sizes.json' file in the SDK
 /// Maps a kernel object to the size of the object, specified in bits.
-#[derive(Deserialize)]
+#[derive(Debug, Deserialize)]
 pub struct ObjectSizes {
     pub tcb: u64,
     pub endpoint: u64,
@@ -305,29 +319,14 @@ pub struct Config {
     pub invocations_labels: serde_json::Value,
     /// Kernel object sizes, used for kernel boot emulation and untyped allocation.
     pub object_sizes: Option<ObjectSizes>,
+    /// Kernel address space constants
+    pub address_space_constants: AddressSpaceConstants,
     /// The two remaining fields are only valid on ARM and RISC-V
     pub device_regions: Option<Vec<PlatformConfigRegion>>,
     pub normal_regions: Option<Vec<PlatformConfigRegion>>,
 }
 
 impl Config {
-    /// Refers to 'seL4_UserVSpaceTop'. Is inclusive.
-    // TODO: We should auto-extract this from libsel4 headers.
-    pub fn user_vspace_top(&self) -> u64 {
-        match self.arch {
-            Arch::Aarch64 => match self.hypervisor {
-                true => match self.arm_pa_size_bits.unwrap() {
-                    40 => 0x00ffffffffff,
-                    44 => 0x0fffffffffff,
-                    _ => panic!("Unknown ARM physical address size bits"),
-                },
-                false => 0x7fffffffffff,
-            },
-            Arch::Riscv64 => 0x0000003fffffefff,
-            Arch::X86_64 => 0x7fffffffefff,
-        }
-    }
-
     /// Refers to the 'PPTR_BASE' define in kernel source
     pub fn virtual_base(&self) -> u64 {
         match self.arch {
@@ -351,7 +350,7 @@ impl Config {
     /// IPC Buffer is located at the highest possible virtual memory page
     pub fn pd_ipc_buffer(&self) -> u64 {
         // user_top is inclusive, so we mask off the bits inside the page.
-        self.user_vspace_top() & !(PageSize::Small as u64 - 1)
+        self.address_space_constants.vspace_user_top & !(PageSize::Small as u64 - 1)
     }
 
     /// The stack is located in the third highest possible virtual memory pages,
@@ -379,7 +378,7 @@ impl Config {
     /// Value is exclusive ..max)
     pub fn vm_map_max_vaddr(&self) -> u64 {
         // Add 1, because user_top is inclusive. Note this assumes no overflow.
-        self.user_vspace_top() + 1
+        self.address_space_constants.vspace_user_top + 1
     }
 
     pub fn paddr_to_kernel_vaddr(&self, paddr: u64) -> u64 {
@@ -403,6 +402,40 @@ impl Config {
             Arch::Riscv64 => self.riscv_pt_levels.unwrap().levels(),
             // seL4 only supports 4-level page table on x86-64.
             Arch::X86_64 => 4,
+        }
+    }
+
+    pub fn vspace_root_level(&self) -> usize {
+        if self.arch == Arch::Aarch64 && self.aarch64_vspace_s2_start_l1() {
+            1
+        } else {
+            0
+        }
+    }
+
+    pub fn vspace_level_index_bits(&self, level: usize) -> u64 {
+        assert!(level < self.num_page_table_levels());
+
+        if self.arch == Arch::Aarch64 && level == self.vspace_root_level() {
+            self.address_space_constants.vspace_index_bits.expect(
+                "Error: An Aarch64 build should have seL4_VSpaceIndexBits defined
+                    by seL4, captured in tool/microkit/address_space_constants.h",
+            )
+        } else {
+            self.address_space_constants.page_table_index_bits
+        }
+    }
+
+    pub fn io_page_table_index_bits(&self) -> u64 {
+        match (self.arch, self.iommu) {
+            (Arch::X86_64, true) => self
+                .address_space_constants
+                .io_page_table_index_bits
+                .expect(
+                    "Error: An x86 VT-D build should have seL4_IOPageTableIndexBits
+                    defined by seL4, captured in tool/microkit/address_space_constants.h",
+                ),
+            _ => panic!("Error: currently not supported by Microkit."),
         }
     }
 }

--- a/tool/microkit/tests/test.rs
+++ b/tool/microkit/tests/test.rs
@@ -34,6 +34,12 @@ const DEFAULT_AARCH64_KERNEL_CONFIG: sel4::Config = sel4::Config {
     device_regions: None,
     normal_regions: None,
     object_sizes: None,
+    address_space_constants: sel4::AddressSpaceConstants {
+        page_table_index_bits: 9,
+        vspace_index_bits: Some(10),
+        io_page_table_index_bits: None,
+        vspace_user_top: 0xffffffffff,
+    },
 };
 
 const DEFAULT_X86_64_KERNEL_CONFIG: sel4::Config = sel4::Config {
@@ -59,6 +65,12 @@ const DEFAULT_X86_64_KERNEL_CONFIG: sel4::Config = sel4::Config {
     device_regions: None,
     normal_regions: None,
     object_sizes: None,
+    address_space_constants: sel4::AddressSpaceConstants {
+        page_table_index_bits: 9,
+        vspace_index_bits: None,
+        io_page_table_index_bits: Some(9),
+        vspace_user_top: 0x7fffffffefff,
+    },
 };
 
 fn check_success(kernel_config: &sel4::Config, test_name: &str) {


### PR DESCRIPTION
This commit removes some of the duplicated constants definitions that seL4 already exports.